### PR TITLE
TEC-6582 LinkedIn V1 share response body POJO

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/types/Address.java
+++ b/src/main/java/com/echobox/api/linkedin/types/Address.java
@@ -26,7 +26,7 @@ import lombok.Setter;
  * The type Address type for the linkedin V2 api
  * @author clementcaylux 
  */
-public class AddressV2 {
+public class Address {
 
   @Getter
   @Setter

--- a/src/main/java/com/echobox/api/linkedin/types/organization/LocationInfo.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/LocationInfo.java
@@ -18,7 +18,7 @@
 package com.echobox.api.linkedin.types.organization;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
-import com.echobox.api.linkedin.types.AddressV2;
+import com.echobox.api.linkedin.types.Address;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -42,5 +42,5 @@ public class LocationInfo {
   @Getter
   @Setter
   @LinkedIn
-  private AddressV2 address;
+  private Address address;
 }

--- a/src/main/java/com/echobox/api/linkedin/types/v1/Address.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/Address.java
@@ -22,44 +22,59 @@ import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 import lombok.Getter;
 
 /**
- * Location model
+ * Address model
  * @author Joanna
  *
  */
-public class Location {
+public class Address {
   
   /**
-   * Description of company location.
+   * First line of street address of location.
+   */
+  @Getter
+  @LinkedIn("street1")
+  private String firstStreet;
+  
+  /**
+   * Second line of street address of location.
+   */
+  @Getter
+  @LinkedIn("street2")
+  private String secondStreet;
+  
+  /**
+   * City for location.
    */
   @Getter
   @LinkedIn
-  private String description;
+  private String city;
   
   /**
-   * Valid values are true or false. A value of true matches the Company headquarters location.
+   * State for location.
    */
   @Getter
   @LinkedIn
-  private boolean isHeadquarters;
+  private String state;
   
   /**
-   * Valid values are true or false. A value of true matches the active location.
+   * Postal code for location. Matches companies within a specific postal code.
+   * Must be combined with the country-code parameter. Not supported for all countries.
    */
   @Getter
   @LinkedIn
-  private boolean isActive;
+  private String postalCode;
   
   /**
-   * Address of location.
+   * Country code for location. Matches companies with a location in a specific country.
    */
   @Getter
   @LinkedIn
-  private Address address;
+  private String countryCode;
   
   /**
-   * Company contact information for the location.
+   * Region code for location.
    */
   @Getter
   @LinkedIn
-  private ContactInfo contactInfo;
+  private Integer regionCode;
 }

--- a/src/main/java/com/echobox/api/linkedin/types/v1/Address.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/Address.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
+package com.echobox.api.linkedin.types.v1;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 

--- a/src/main/java/com/echobox/api/linkedin/types/v1/CodeAndNameType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/CodeAndNameType.java
@@ -15,49 +15,36 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
+package com.echobox.api.linkedin.types.v1;
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * StockExchange
+ * Code and name model wrapper
  * @author Joanna
  *
  */
-public enum StockExchange implements CodeType<Integer> {
-  
-  ASE(1, "American Stock Exchange"),
-  NYS(2, "New York Stock Exchange"),
-  NMS(3, "NASDAQ"),
-  LSE(4, "London Stock Exchange"),
-  FRA(5, "Frankfurt Stock Exchange"),
-  GER(6, "XETRA Stock Exchange"),
-  PAR(7, "Euronext Paris");
+@NoArgsConstructor
+@RequiredArgsConstructor
+public class CodeAndNameType {
   
   @Getter
-  private final Integer code;
+  @NonNull
+  @LinkedIn
+  private String code;
   
   @Getter
+  @NonNull
+  @LinkedIn
   private String name;
   
-  StockExchange(int code, String name) {
-    this.code = code;
-    this.name = name;
-  }
-  
-  /**
-   * Convert the provided code into a status type
-   *
-   * @param code the code
-   * @return if successful the desired status type otherwise null
-   */
-  public static StockExchange fromCode(String code) {
-    for (StockExchange stockExchange : StockExchange.values()) {
-      if (stockExchange.getCode().equals(code)) {
-        return stockExchange;
-      }
-    }
-    return null;
+  boolean hasNullFields() {
+    return code == null || name == null;
   }
 
 }

--- a/src/main/java/com/echobox/api/linkedin/types/v1/CodeType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/CodeType.java
@@ -15,47 +15,31 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
+package com.echobox.api.linkedin.types.v1;
 
-import com.echobox.api.linkedin.jsonmapper.LinkedIn;
-
-import lombok.Getter;
-import lombok.Setter;
+import org.apache.commons.lang3.text.WordUtils;
 
 /**
- * The type Address type for the linkedin V2 api
- * @author clementcaylux 
+ * Code type interface
+ * @author Joanna
+ *
+ * @param <T> type
  */
-public class AddressV2 {
-
-  @Getter
-  @Setter
-  @LinkedIn
-  private String postalCode;
-
-  @Getter
-  @Setter
-  @LinkedIn
-  private String country;
-
-  @Getter
-  @Setter
-  @LinkedIn
-  private String geographicArea;
-
-  @Getter
-  @Setter
-  @LinkedIn
-  private String line1;
-
-  @Getter
-  @Setter
-  @LinkedIn
-  private String line2;
-
-  @Getter
-  @Setter
-  @LinkedIn
-  private String city;
+public interface CodeType<T> {
   
+  /**
+   * Get the code
+   * @return code
+   */
+  T getCode();
+  
+  /**
+   * Get the name
+   * @return name
+   */
+  default String getName() {
+    String name = toString();
+    return WordUtils.capitalize(name.replaceAll("_", " ").toLowerCase());
+  }
+
 }

--- a/src/main/java/com/echobox/api/linkedin/types/v1/Company.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/Company.java
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
+package com.echobox.api.linkedin.types.v1;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import com.echobox.api.linkedin.types.LinkedInIdAndNameType;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/echobox/api/linkedin/types/v1/CompanyType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/CompanyType.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
+package com.echobox.api.linkedin.types.v1;
 
 import com.echobox.api.linkedin.logging.LinkedInLogger;
 

--- a/src/main/java/com/echobox/api/linkedin/types/v1/ContactInfo.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/ContactInfo.java
@@ -15,31 +15,37 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
+package com.echobox.api.linkedin.types.v1;
 
-import org.apache.commons.lang3.text.WordUtils;
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+
+import lombok.Getter;
 
 /**
- * Code type interface
+ * Contact info model
  * @author Joanna
  *
- * @param <T> type
  */
-public interface CodeType<T> {
+public class ContactInfo {
   
   /**
-   * Get the code
-   * @return code
+   * Company phone number for the location.
    */
-  T getCode();
-  
-  /**
-   * Get the name
-   * @return name
-   */
-  default String getName() {
-    String name = toString();
-    return WordUtils.capitalize(name.replaceAll("_", " ").toLowerCase());
-  }
+  @Getter
+  @LinkedIn("phone1")
+  private String phoneOne;
 
+  /**
+   * Second company phone number for the location.
+   */
+  @Getter
+  @LinkedIn("phone2")
+  private String phoneTwo;
+
+  /**
+   * Company fax number for the location.
+   */
+  @Getter
+  @LinkedIn
+  private String fax;
 }

--- a/src/main/java/com/echobox/api/linkedin/types/v1/EmployeeCountRange.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/EmployeeCountRange.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
+package com.echobox.api.linkedin.types.v1;
 
 import com.echobox.api.linkedin.logging.LinkedInLogger;
 

--- a/src/main/java/com/echobox/api/linkedin/types/v1/IndustryCode.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/IndustryCode.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
+package com.echobox.api.linkedin.types.v1;
 
 import com.echobox.api.linkedin.logging.LinkedInLogger;
 

--- a/src/main/java/com/echobox/api/linkedin/types/v1/Location.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/Location.java
@@ -15,47 +15,51 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
+package com.echobox.api.linkedin.types.v1;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 
 import lombok.Getter;
-import lombok.Setter;
 
 /**
- * The type Address type for the linkedin V2 api
- * @author clementcaylux 
+ * Location model
+ * @author Joanna
+ *
  */
-public class AddressV2 {
-
-  @Getter
-  @Setter
-  @LinkedIn
-  private String postalCode;
-
-  @Getter
-  @Setter
-  @LinkedIn
-  private String country;
-
-  @Getter
-  @Setter
-  @LinkedIn
-  private String geographicArea;
-
-  @Getter
-  @Setter
-  @LinkedIn
-  private String line1;
-
-  @Getter
-  @Setter
-  @LinkedIn
-  private String line2;
-
-  @Getter
-  @Setter
-  @LinkedIn
-  private String city;
+public class Location {
   
+  /**
+   * Description of company location.
+   */
+  @Getter
+  @LinkedIn
+  private String description;
+  
+  /**
+   * Valid values are true or false. A value of true matches the Company headquarters location.
+   */
+  @Getter
+  @LinkedIn
+  private boolean isHeadquarters;
+  
+  /**
+   * Valid values are true or false. A value of true matches the active location.
+   */
+  @Getter
+  @LinkedIn
+  private boolean isActive;
+  
+  /**
+   * Address of location.
+   */
+  @Getter
+  @LinkedIn
+  private Address address;
+  
+  /**
+   * Company contact information for the location.
+   */
+  @Getter
+  @LinkedIn
+  private ContactInfo contactInfo;
 }

--- a/src/main/java/com/echobox/api/linkedin/types/v1/Share.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/Share.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.v1;
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+/**
+ * Share request body model
+ * @see <a href="https://developer.linkedin.com/docs/share-on-linkedin">Share on LinkedIn</a>
+ * @author Joanna
+ *
+ */
+@AllArgsConstructor
+public class Share {
+
+  /**
+   * A collection of fields describing the shared content.
+   */
+  @Getter
+  @Setter
+  @LinkedIn
+  private Content content;
+  
+  /**
+   * A comment by the member to associated with the share.
+   */
+  @Getter
+  @Setter
+  @LinkedIn
+  private String comment;
+  
+  /**
+   * A collection of visibility information about the share.
+   */
+  @Getter
+  @NonNull
+  @LinkedIn
+  private Visibility visibility;
+  
+  @Getter
+  @Setter
+  @LinkedIn
+  private Targeting shareTargetReach;
+  
+  /**
+   * A collection of fields describing the shared content.
+   * @author Joanna
+   *
+   */
+  @AllArgsConstructor
+  public static class Content {
+    
+    /**
+     * The title of the content being shared.
+     */
+    @Getter
+    @Setter
+    @LinkedIn
+    private String title;
+    
+    /**
+     * The description of the content being shared.
+     */
+    @Getter
+    @Setter
+    @LinkedIn
+    private String description;
+    
+    /**
+     * A fully qualified URL for the content being shared.
+     */
+    @Getter
+    @Setter
+    @LinkedIn
+    private String submittedURL;
+    
+    /**
+     * A fully qualified URL to a thumbnail image to accompany the shared content.
+     */
+    @Getter
+    @Setter
+    @LinkedIn
+    private String submittedImageURL;
+    
+  }
+  
+  /**
+   * A collection of visibility information about the share.
+   * @author Joanna
+   *
+   */
+  @AllArgsConstructor
+  public static class Visibility {
+    
+    /**
+     * One of the following values:
+     * anyone:  Share will be visible to all members.
+     * connections-only:  Share will only be visible to connections of the member performing the
+     * share.
+     */
+    @Getter
+    @Setter
+    @NonNull
+    @LinkedIn
+    private String code;
+    
+  }
+  
+  /**
+   * Targeting POJO
+   * @see <a href="https://developer.linkedin.com/docs/company-pages#targetting_shares">
+   * Share on LinkedIn</a>
+   * @author Joanna
+   *
+   */
+  @AllArgsConstructor
+  public static class Targeting {
+    
+    @Getter
+    @LinkedIn
+    private ShareTargets shareTargets;
+    
+  }
+  
+  /**
+   * Share targets POJO
+   * @author Joanna
+   *
+   */
+  @AllArgsConstructor
+  public static class ShareTargets {
+    
+    @Getter
+    @LinkedIn
+    private ShareTarget shareTarget;
+    
+  }
+  
+  /**
+   * Share Target POJO
+   * @author Joanna
+   *
+   */
+  @AllArgsConstructor
+  public static class ShareTarget {
+    
+    @Getter
+    @LinkedIn
+    private Tvalues tvalues;
+    
+    @Getter
+    @LinkedIn
+    private String code;
+    
+  }
+  
+  /**
+   * Tvalues POJO
+   * @author Joanna
+   *
+   */
+  @AllArgsConstructor
+  public static class Tvalues {
+    
+    @Getter
+    @LinkedIn
+    private String tvalue;
+    
+  }
+  
+}
+
+

--- a/src/main/java/com/echobox/api/linkedin/types/v1/StatusType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/StatusType.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
+package com.echobox.api.linkedin.types.v1;
 
 import com.echobox.api.linkedin.logging.LinkedInLogger;
 

--- a/src/main/java/com/echobox/api/linkedin/types/v1/StockExchange.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/StockExchange.java
@@ -15,37 +15,49 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
-
-import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+package com.echobox.api.linkedin.types.v1;
 
 import lombok.Getter;
 
 /**
- * Contact info model
+ * StockExchange
  * @author Joanna
  *
  */
-public class ContactInfo {
+public enum StockExchange implements CodeType<Integer> {
+  
+  ASE(1, "American Stock Exchange"),
+  NYS(2, "New York Stock Exchange"),
+  NMS(3, "NASDAQ"),
+  LSE(4, "London Stock Exchange"),
+  FRA(5, "Frankfurt Stock Exchange"),
+  GER(6, "XETRA Stock Exchange"),
+  PAR(7, "Euronext Paris");
+  
+  @Getter
+  private final Integer code;
+  
+  @Getter
+  private String name;
+  
+  StockExchange(int code, String name) {
+    this.code = code;
+    this.name = name;
+  }
   
   /**
-   * Company phone number for the location.
+   * Convert the provided code into a status type
+   *
+   * @param code the code
+   * @return if successful the desired status type otherwise null
    */
-  @Getter
-  @LinkedIn("phone1")
-  private String phoneOne;
+  public static StockExchange fromCode(String code) {
+    for (StockExchange stockExchange : StockExchange.values()) {
+      if (stockExchange.getCode().equals(code)) {
+        return stockExchange;
+      }
+    }
+    return null;
+  }
 
-  /**
-   * Second company phone number for the location.
-   */
-  @Getter
-  @LinkedIn("phone2")
-  private String phoneTwo;
-
-  /**
-   * Company fax number for the location.
-   */
-  @Getter
-  @LinkedIn
-  private String fax;
 }

--- a/src/main/java/com/echobox/api/linkedin/types/v1/Update.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/Update.java
@@ -15,36 +15,26 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
+package com.echobox.api.linkedin.types.v1;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
 /**
- * Code and name model wrapper
+ * The update POJO
+ * @see <a href="https://developer.linkedin.com/docs/share-on-linkedin">Share on LinkedIn</a>
  * @author Joanna
  *
  */
-@NoArgsConstructor
-@RequiredArgsConstructor
-public class CodeAndNameType {
+public class Update {
   
   @Getter
-  @NonNull
   @LinkedIn
-  private String code;
+  private String updateKey;
   
   @Getter
-  @NonNull
   @LinkedIn
-  private String name;
-  
-  boolean hasNullFields() {
-    return code == null || name == null;
-  }
+  private String updateUrl;
 
 }

--- a/src/test/java/com/echobox/api/linkedin/jsonmapper/DefaultJsonMapperTest.java
+++ b/src/test/java/com/echobox/api/linkedin/jsonmapper/DefaultJsonMapperTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.echobox.api.linkedin.types.Annotation;
-import com.echobox.api.linkedin.types.Company;
 import com.echobox.api.linkedin.types.ContentEntity;
 import com.echobox.api.linkedin.types.DistributionTarget;
 import com.echobox.api.linkedin.types.Share;
@@ -48,6 +47,7 @@ import com.echobox.api.linkedin.types.urn.location.CountryURN;
 import com.echobox.api.linkedin.types.urn.location.PlaceURN;
 import com.echobox.api.linkedin.types.urn.location.RegionURN;
 import com.echobox.api.linkedin.types.urn.location.StateURN;
+import com.echobox.api.linkedin.types.v1.Company;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/com/echobox/api/linkedin/jsonmapper/LinkedInJsonMapperV1Test.java
+++ b/src/test/java/com/echobox/api/linkedin/jsonmapper/LinkedInJsonMapperV1Test.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.echobox.api.linkedin.types.Company;
-import com.echobox.api.linkedin.types.Location;
+import com.echobox.api.linkedin.types.v1.Company;
+import com.echobox.api.linkedin.types.v1.Location;
 
 import org.junit.Test;
 

--- a/src/test/java/com/echobox/api/linkedin/jsonmapper/SimpleJSON.java
+++ b/src/test/java/com/echobox/api/linkedin/jsonmapper/SimpleJSON.java
@@ -17,7 +17,7 @@
 
 package com.echobox.api.linkedin.jsonmapper;
 
-import com.echobox.api.linkedin.types.CodeAndNameType;
+import com.echobox.api.linkedin.types.v1.CodeAndNameType;
 
 import lombok.Getter;
 

--- a/src/test/java/com/echobox/api/linkedin/types/CompanyTypeTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/CompanyTypeTest.java
@@ -19,6 +19,8 @@ package com.echobox.api.linkedin.types;
 
 import static org.junit.Assert.assertEquals;
 
+import com.echobox.api.linkedin.types.v1.CompanyType;
+
 import org.junit.Test;
 
 /**

--- a/src/test/java/com/echobox/api/linkedin/types/StatusTypeTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/StatusTypeTest.java
@@ -19,6 +19,8 @@ package com.echobox.api.linkedin.types;
 
 import static org.junit.Assert.assertEquals;
 
+import com.echobox.api.linkedin.types.v1.StatusType;
+
 import org.junit.Test;
 
 /**


### PR DESCRIPTION
### Description of Changes
Move LinkedIn V1 into it's own package, created POJOs for share body and response

### Documentation
https://developer.linkedin.com/docs/share-on-linkedin
https://developer.linkedin.com/docs/company-pages#targetting_shares

### Risks & Impacts
Enables posting to LinkedIn via V1

### Testing
Tested with snippet:
```
Content content = new Content("Iccccyyyy",
        "Leverage LinkedIn's APIs to maximize engagement",
        "https://www.bbc.co.uk/news/world-europe-46386867",
        "https://i.ytimg.com/vi/mRf3-JkwqfU/hqdefault.jpg");
    Tvalues tvalues = new Tvalues("na");
    ShareTarget shareTarget = new ShareTarget(tvalues, "geos");

    Targeting targeting = new Targeting(new ShareTargets(shareTarget));
    Share share = new Share(content, null, new Visibility("anyone"), targeting);

    DefaultLinkedInClient client = new DefaultLinkedInClient([accessToken], Version.V1);
    Update publish = client.publish("companies/[companyId]/shares", Update.class, share,
        new Parameter[0]);
```