### PR TITLE
TEC-7379 Ensure LinkedIn SDK UGC is not a typo

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/connection/v2/UGCShareConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/UGCShareConnection.java
@@ -20,8 +20,8 @@ package com.echobox.api.linkedin.connection.v2;
 import com.echobox.api.linkedin.client.Connection;
 import com.echobox.api.linkedin.client.LinkedInClient;
 import com.echobox.api.linkedin.client.Parameter;
-import com.echobox.api.linkedin.types.ucg.UGCShare;
-import com.echobox.api.linkedin.types.ucg.ViewContext;
+import com.echobox.api.linkedin.types.ugc.UGCShare;
+import com.echobox.api.linkedin.types.ugc.ViewContext;
 import com.echobox.api.linkedin.types.urn.URN;
 import com.echobox.api.linkedin.util.URLUtils;
 
@@ -56,9 +56,9 @@ public class UGCShareConnection extends ConnectionBaseV2 {
    * the media field
    * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#create-ugc-posts">Create UGC Post</a>
    * @param shareBody the share body
-   * @return the created UCG share
+   * @return the created UGC share
    */
-  public UGCShare createUCGPost(UGCShare shareBody) {
+  public UGCShare createUGCPost(UGCShare shareBody) {
     return linkedinClient.publish(UGC_POST, UGCShare.class, shareBody);
   }
   
@@ -70,7 +70,7 @@ public class UGCShareConnection extends ConnectionBaseV2 {
    * @param viewContext the context in which the user generated content is being viewed
    * @return the UGC post from the share URN
    */
-  public UGCShare retrieveUCGPost(URN shareURN, ViewContext viewContext) {
+  public UGCShare retrieveUGCPost(URN shareURN, ViewContext viewContext) {
     Parameter viewContextParam = Parameter.with(VIEW_CONTEXT, viewContext);
     return linkedinClient.fetchObject(UGC_POST + "/" + URLUtils.urlDecode(shareURN.toString()),
         UGCShare.class, viewContextParam);
@@ -92,7 +92,7 @@ public class UGCShareConnection extends ConnectionBaseV2 {
    * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#retrieve-ugc-posts-by-authors">Retrieve UGC Postsby authors</a>
    * @param authorURN the author URN - can be either an organization or person URN
    * @param count the number of entries to be returned per paged request
-   * @return the connection of UCG share which is paged
+   * @return the connection of UGC share which is paged
    */
   public Connection<UGCShare> retrieveUGCPostsByAuthors(URN authorURN, Integer count) {
     List<Parameter> parameters = new ArrayList<>();

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/Commentary.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/Commentary.java
@@ -15,34 +15,43 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
+package com.echobox.api.linkedin.types.ugc;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import com.echobox.api.linkedin.types.social.actions.CommentAction;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
 /**
- * Distribution
- * @see
- * <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#distribution">Distribution</a>
+ * Commentary
  * @author joanna
  */
-public class Distribution {
+public class Commentary {
   
   /**
-   * Whether UGC post is distributed to follow-feed or not.
+   * User generated attributes in the text.
    */
   @Getter
+  @Setter
   @LinkedIn
-  private boolean distributedViaFollowFeed;
+  private List<CommentAction.Attribute> attributes;
   
   /**
-   * External distribution channels that this content is distributed to.
+   * The locale that may have be inferred for this text.
    */
   @Getter
+  @Setter
   @LinkedIn
-  private List<String> externalDistributionChannels;
-
+  private String inferredLocale;
+  
+  /**
+   * The text content that may be attributed.
+   */
+  @Getter
+  @Setter
+  @LinkedIn
+  private String text;
 }

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/Distribution.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/Distribution.java
@@ -15,28 +15,34 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
+package com.echobox.api.linkedin.types.ugc;
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+
+import lombok.Getter;
+
+import java.util.List;
 
 /**
- * External distribution channel type
- * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#distribution">External Distribution Channel Type</a>
+ * Distribution
+ * @see
+ * <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#distribution">Distribution</a>
  * @author joanna
  */
-public enum ExternalDistributionChannelType {
+public class Distribution {
   
   /**
-   * Distribute content to Twitter
+   * Whether UGC post is distributed to follow-feed or not.
    */
-  TWITTER,
+  @Getter
+  @LinkedIn
+  private boolean distributedViaFollowFeed;
   
   /**
-   * Distribute content to Tencent
+   * External distribution channels that this content is distributed to.
    */
-  TENCENT,
-  
-  /**
-   * Distribute content to Weibo
-   */
-  WEIBO;
+  @Getter
+  @LinkedIn
+  private List<String> externalDistributionChannels;
 
 }

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ExternalDistributionChannelType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ExternalDistributionChannelType.java
@@ -15,22 +15,28 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
+package com.echobox.api.linkedin.types.ugc;
 
 /**
- * The context in which the user generated content is being viewed.
+ * External distribution channel type
+ * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#distribution">External Distribution Channel Type</a>
  * @author joanna
  */
-public enum ViewContext {
+public enum ExternalDistributionChannelType {
   
   /**
-   * View the content as the author
+   * Distribute content to Twitter
    */
-  AUTHOR,
+  TWITTER,
   
   /**
-   * View the content as a reader
+   * Distribute content to Tencent
    */
-  READER;
+  TENCENT,
   
+  /**
+   * Distribute content to Weibo
+   */
+  WEIBO;
+
 }

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/LifeCycleState.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/LifeCycleState.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
+package com.echobox.api.linkedin.types.ugc;
 
 /**
  * The state of the content

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/Origin.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/Origin.java
@@ -15,43 +15,57 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
-
-import com.echobox.api.linkedin.jsonmapper.LinkedIn;
-import com.echobox.api.linkedin.types.social.actions.CommentAction;
-
-import lombok.Getter;
-import lombok.Setter;
-
-import java.util.List;
+package com.echobox.api.linkedin.types.ugc;
 
 /**
- * Commentary
+ * Origin
  * @author joanna
  */
-public class Commentary {
+public enum Origin {
   
   /**
-   * User generated attributes in the text.
+   * Partner using external API
    */
-  @Getter
-  @Setter
-  @LinkedIn
-  private List<CommentAction.Attribute> attributes;
+  API,
   
   /**
-   * The locale that may have be inferred for this text.
+   * Elevate app
    */
-  @Getter
-  @Setter
-  @LinkedIn
-  private String inferredLocale;
+  ELEVATE,
   
   /**
-   * The text content that may be attributed.
+   * Firefox browser extension
    */
-  @Getter
-  @Setter
-  @LinkedIn
-  private String text;
+  FIREFOX,
+  
+  /**
+   * Mobile flagship app
+   */
+  FLAGSHIP,
+  
+  /**
+   * InShare on 3rd party sites
+   */
+  IN_SHARE,
+  
+  /**
+   * Desktop site
+   */
+  DESKTOP,
+  
+  /**
+   * Sales Navigator
+   */
+  LSS,
+  
+  /**
+   * Pulse app
+   */
+  PULSE,
+  
+  /**
+   * InShare on Slideshare
+   */
+  SLIDESHARE;
+
 }

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ResponseContext.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ResponseContext.java
@@ -15,57 +15,34 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
+package com.echobox.api.linkedin.types.ugc;
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import com.echobox.api.linkedin.types.urn.URN;
+
+import lombok.Getter;
 
 /**
- * Origin
+ * Response context
+ * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#responsecontext">Response Context</a>
  * @author joanna
  */
-public enum Origin {
+public class ResponseContext {
   
   /**
-   * Partner using external API
+   * The content that a piece of content is a response to. Currently, the only supported Urn is
+   * ugcPost Urn.
    */
-  API,
+  @LinkedIn
+  @Getter
+  private URN parent;
   
   /**
-   * Elevate app
+   * The greatest ancestor content that a piece of content is a response to. Currently, the only
+   * supported Urn is ugcPost Urn.
    */
-  ELEVATE,
-  
-  /**
-   * Firefox browser extension
-   */
-  FIREFOX,
-  
-  /**
-   * Mobile flagship app
-   */
-  FLAGSHIP,
-  
-  /**
-   * InShare on 3rd party sites
-   */
-  IN_SHARE,
-  
-  /**
-   * Desktop site
-   */
-  DESKTOP,
-  
-  /**
-   * Sales Navigator
-   */
-  LSS,
-  
-  /**
-   * Pulse app
-   */
-  PULSE,
-  
-  /**
-   * InShare on Slideshare
-   */
-  SLIDESHARE;
+  @LinkedIn
+  @Getter
+  private URN root;
 
 }

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ShareContent.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ShareContent.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
+package com.echobox.api.linkedin.types.ugc;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 import com.echobox.api.linkedin.types.urn.URN;

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ShareMedia.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ShareMedia.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
+package com.echobox.api.linkedin.types.ugc;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 import com.echobox.api.linkedin.types.urn.URN;

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ShareMediaCategory.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ShareMediaCategory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
+package com.echobox.api.linkedin.types.ugc;
 
 /**
  * Share media category

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/TargetAudience.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/TargetAudience.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
+package com.echobox.api.linkedin.types.ugc;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 import com.echobox.api.linkedin.types.objectype.Locale;

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/UGCShare.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/UGCShare.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
+package com.echobox.api.linkedin.types.ugc;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 import com.echobox.api.linkedin.types.LinkedInURNIdType;
@@ -28,8 +28,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 /**
- * UCG Share
- * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#schema">UCG Share</a>
+ * UGC Share
+ * @see
+ * <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#schema">UGC Share</a>
  * @author joanna
  */
 @RequiredArgsConstructor

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ViewContext.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ViewContext.java
@@ -15,34 +15,22 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
-
-import com.echobox.api.linkedin.jsonmapper.LinkedIn;
-import com.echobox.api.linkedin.types.urn.URN;
-
-import lombok.Getter;
+package com.echobox.api.linkedin.types.ugc;
 
 /**
- * Response context
- * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#responsecontext">Response Context</a>
+ * The context in which the user generated content is being viewed.
  * @author joanna
  */
-public class ResponseContext {
+public enum ViewContext {
   
   /**
-   * The content that a piece of content is a response to. Currently, the only supported Urn is
-   * ugcPost Urn.
+   * View the content as the author
    */
-  @LinkedIn
-  @Getter
-  private URN parent;
+  AUTHOR,
   
   /**
-   * The greatest ancestor content that a piece of content is a response to. Currently, the only
-   * supported Urn is ugcPost Urn.
+   * View the content as a reader
    */
-  @LinkedIn
-  @Getter
-  private URN root;
-
+  READER;
+  
 }

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/Visibility.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/Visibility.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types.ucg;
+package com.echobox.api.linkedin.types.ugc;
 
 /**
  * Visibility enum

--- a/src/test/java/com/echobox/api/linkedin/types/ugc/UGCShareTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/ugc/UGCShareTest.java
@@ -24,11 +24,6 @@ import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapper;
 import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapperTestBase;
 import com.echobox.api.linkedin.types.objectype.AuditStamp;
 import com.echobox.api.linkedin.types.social.actions.CommentAction;
-import com.echobox.api.linkedin.types.ucg.Commentary;
-import com.echobox.api.linkedin.types.ucg.ShareContent;
-import com.echobox.api.linkedin.types.ucg.ShareMedia;
-import com.echobox.api.linkedin.types.ucg.TargetAudience;
-import com.echobox.api.linkedin.types.ucg.UGCShare;
 import com.echobox.api.linkedin.types.urn.URN;
 
 import org.junit.Test;


### PR DESCRIPTION
### Description of Changes

- Update all typos UCG -> UGC which should be the correct spelling - duh!

### Documentation

https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api

### Risks & Impacts

Will break any existing external usages of UGC package

### Testing

The project builds successfully
