### PR TITLE
TEC-7363 

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/client/DebugHeaderInfo.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DebugHeaderInfo.java
@@ -52,16 +52,21 @@ public class DebugHeaderInfo {
 
   /**
    * Initialise the debug header info
-   * @param fabic x-li-fabric header
+   * @param fabric x-li-fabric header
    * @param format x-li-format header
    * @param requestId x-li-request-id request id
    * @param uuid x-li-uuid header
    */
-  public DebugHeaderInfo(String fabic, String format, String requestId, String uuid) {
-    this.fabric = fabic;
+  public DebugHeaderInfo(String fabric, String format, String requestId, String uuid) {
+    this.fabric = fabric;
     this.format = format;
     this.requestId = requestId;
     this.uuid = uuid;
   }
-
+  
+  @Override
+  public String toString() {
+    return String.format("DebugHeaderInfo [x-li-fabric=%s, x-li-format=%s, x-li-request-id=%s, "
+        + "x-li-uuid=%s]", fabric, format, requestId, uuid);
+  }
 }


### PR DESCRIPTION
### Description of Changes

- Override toString for DebugHeaderInfo so the DebugHeaderInfo can be formatted
- Fix a typo - fabic -> fabric

### Documentation

[Documentation on LinkedIn error handler](https://docs.microsoft.com/en-us/linkedin/shared/api-guide/concepts/error-handling?context=linkedin/consumer/context)

### Risks & Impacts

- Will update how `DebugHeaderInfo.toString` is formatted

### Testing

Ran the snippet:
```
DebugHeaderInfo header = new DebugHeaderInfo(null, "format", "requestId", "uuid");
System.out.println(header);
```
