### PR TITLE
TEC-7375 Equals and Hash methods for TargeAudience

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/types/objectype/Locale.java
+++ b/src/main/java/com/echobox/api/linkedin/types/objectype/Locale.java
@@ -19,6 +19,7 @@ package com.echobox.api.linkedin.types.objectype;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /**
@@ -28,6 +29,7 @@ import lombok.Getter;
  * @author joanna
  *
  */
+@EqualsAndHashCode
 public class Locale {
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/TargetAudience.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/TargetAudience.java
@@ -21,6 +21,7 @@ import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 import com.echobox.api.linkedin.types.objectype.Locale;
 import com.echobox.api.linkedin.types.urn.URN;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.List;
@@ -31,6 +32,7 @@ import java.util.List;
  * <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#targetaudience">Target Audience</a>
  * @author joanna
  */
+@EqualsAndHashCode
 public class TargetAudience {
   
   /**
@@ -44,6 +46,7 @@ public class TargetAudience {
    * TargetAudienceEntity
    * @author joanna
    */
+  @EqualsAndHashCode
   public static class TargetAudienceEntity {
     
     /**

--- a/src/test/java/com/echobox/api/linkedin/types/ugc/TargetAudienceTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/ugc/TargetAudienceTest.java
@@ -72,7 +72,7 @@ public class TargetAudienceTest extends DefaultJsonMapperTestBase {
     String json = "{}";
     TargetAudience other = defaultJsonMapper.toJavaObject(json, TargetAudience.class);
     assertNotEquals(this.targetAudience, other);
-    assertNotEquals(this.hashCode(), other.hashCode());
+    assertNotEquals(this.targetAudience.hashCode(), other.hashCode());
   }
   
   private TargetAudience getInstance() {

--- a/src/test/java/com/echobox/api/linkedin/types/ugc/TargetAudienceTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/ugc/TargetAudienceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.ugc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapper;
+import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapperTestBase;
+import com.echobox.api.linkedin.types.objectype.Locale;
+import com.echobox.api.linkedin.types.urn.URN;
+
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Target Audience Tests
+ * @author Alexandros
+ */
+public class TargetAudienceTest extends DefaultJsonMapperTestBase {
+  
+  private DefaultJsonMapper defaultJsonMapper = new DefaultJsonMapper();
+  
+  private TargetAudience targetAudience = getInstance();
+  
+  @Test
+  public void targetAudienceTest() {
+    assertNotNull(targetAudience);
+    assertEquals(1, targetAudience.getTargetedEntities().size());
+  
+    TargetAudience.TargetAudienceEntity entity = targetAudience.getTargetedEntities().get(0);
+    assertEquals(2, entity.getDegrees().size());
+    assertEquals(new URN("urn:li:degree:258"), entity.getDegrees().get(0));
+  
+    List<Locale> locales = entity.getInterfaceLocales();
+    assertEquals(1, locales.size());
+    assertEquals("US", locales.get(0).getCountry());
+    assertEquals("en", locales.get(0).getLanguage());
+  }
+  
+  @Test
+  public void testEqualWithSameInstance() {
+    assertEquals(targetAudience, targetAudience);
+  }
+  
+  @Test
+  public void testEqualsAndHashCodeWithDifferentInstance() {
+    TargetAudience other = getInstance();
+    assertEquals(targetAudience, other);
+    assertEquals(targetAudience.hashCode(), other.hashCode());
+  }
+  
+  @Test
+  public void testNotEqualWithANewModifiedInstance() {
+    String json = "{}";
+    TargetAudience other = defaultJsonMapper.toJavaObject(json, TargetAudience.class);
+    assertNotEquals(this.targetAudience, other);
+    assertNotEquals(this.hashCode(), other.hashCode());
+  }
+  
+  private TargetAudience getInstance() {
+    String json = readFileToString("com.echobox.api.linkedin.jsonmapper/targetAudience.json");
+    return defaultJsonMapper.toJavaObject(json, TargetAudience.class);
+  }
+}

--- a/src/test/resources/com.echobox.api.linkedin.jsonmapper/targetAudience.json
+++ b/src/test/resources/com.echobox.api.linkedin.jsonmapper/targetAudience.json
@@ -1,0 +1,36 @@
+{
+  "targetedEntities": [
+    {
+      "degrees": [
+        "urn:li:degree:258",
+        "urn:li:degree:125"
+      ],
+      "fieldsOfStudy": [
+        "urn:li:fieldOfStudy:100002",
+        "urn:li:fieldOfStudy:100001",
+        "urn:li:fieldOfStudy:100004"
+      ],
+      "industries": [
+        "urn:li:industry:3"
+      ],
+      "interfaceLocales" : [
+        {
+          "country": "US",
+          "language": "en"
+        }
+      ],
+      "locations": [
+        "urn:li:country:us"
+      ],
+      "schools": [
+        "urn:li:school:17914",
+        "urn:li:school:17414"
+      ],
+      "seniorities": [
+        "urn:li:seniority:2",
+        "urn:li:seniority:1"
+      ],
+      "staffCountRanges": "SIZE_51_TO_200"
+    }
+  ]
+}


### PR DESCRIPTION
### Description of Changes

Using the @EqualsAndHashCode to generate the equals and hash code method for TargetAudience.

### Documentation

N/A

### Risks & Impacts

Small risk as it adds specific implementations for the TargetAudience.

### Testing

- added some unit tests.
