### PR TITLE
TEC-7375 Setters and Serialisable for target audience a

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/connection/ConnectionBase.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/ConnectionBase.java
@@ -58,7 +58,7 @@ public abstract class ConnectionBase {
   }
   
   protected void validateURN(URNEntityType urnEntityType, URN urn) {
-    if (!urnEntityType.equals(urn.getURNEntityType())) {
+    if (!urnEntityType.equals(urn.resolveURNEntityType())) {
       throw new IllegalArgumentException("The URN should be type " + urnEntityType);
     }
   }

--- a/src/main/java/com/echobox/api/linkedin/types/objectype/Locale.java
+++ b/src/main/java/com/echobox/api/linkedin/types/objectype/Locale.java
@@ -21,6 +21,9 @@ import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
 
 /**
  * Locale POJO
@@ -30,12 +33,15 @@ import lombok.Getter;
  *
  */
 @EqualsAndHashCode
-public class Locale {
+public class Locale implements Serializable {
+  
+  private static final long serialVersionUID = -1L;
 
   /**
    * An uppercase two-letter country code as defined by ISO-3166.
    */
   @Getter
+  @Setter
   @LinkedIn
   private String country;
   
@@ -43,6 +49,7 @@ public class Locale {
    * A lowercase two-letter language code as defined by ISO-639.
    */
   @Getter
+  @Setter
   @LinkedIn
   private String language;
   

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/TargetAudience.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/TargetAudience.java
@@ -23,7 +23,9 @@ import com.echobox.api.linkedin.types.urn.URN;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -33,12 +35,15 @@ import java.util.List;
  * @author joanna
  */
 @EqualsAndHashCode
-public class TargetAudience {
+public class TargetAudience implements Serializable {
+  
+  private static final long serialVersionUID = -1L;
   
   /**
    * The entities targeted for distribution.
    */
   @Getter
+  @Setter
   @LinkedIn
   private List<TargetAudienceEntity> targetedEntities;
   
@@ -47,12 +52,15 @@ public class TargetAudience {
    * @author joanna
    */
   @EqualsAndHashCode
-  public static class TargetAudienceEntity {
+  public static class TargetAudienceEntity implements Serializable {
+  
+    private static final long serialVersionUID = -1L;
     
     /**
      * Standardized degrees to be targeted.
      */
     @Getter
+    @Setter
     @LinkedIn
     private List<URN> degrees;
   
@@ -60,6 +68,7 @@ public class TargetAudience {
      * Standardized fields of study to be targeted.
      */
     @Getter
+    @Setter
     @LinkedIn
     private List<URN> fieldsOfStudy;
   
@@ -67,6 +76,7 @@ public class TargetAudience {
      * Industries to be targeted.
      */
     @Getter
+    @Setter
     @LinkedIn
     private List<URN> industries;
     
@@ -74,6 +84,7 @@ public class TargetAudience {
      * Interface locales to be targeted.
      */
     @Getter
+    @Setter
     @LinkedIn
     private List<Locale> interfaceLocales;
   
@@ -81,6 +92,7 @@ public class TargetAudience {
      * Top level groupings of supertitles to be targeted.
      */
     @Getter
+    @Setter
     @LinkedIn
     private List<URN> jobFunctions;
   
@@ -88,6 +100,7 @@ public class TargetAudience {
      * Location to be targeted.
      */
     @Getter
+    @Setter
     @LinkedIn("locations")
     private List<URN> locations;
   
@@ -95,6 +108,7 @@ public class TargetAudience {
      * Standardized schools to be targeted.
      */
     @Getter
+    @Setter
     @LinkedIn
     private List<URN> schools;
     
@@ -102,6 +116,7 @@ public class TargetAudience {
      * Seniorities to be targeted
      */
     @Getter
+    @Setter
     @LinkedIn
     private List<URN> seniorities;
   
@@ -109,6 +124,7 @@ public class TargetAudience {
      * Organization sizes to be targeted.
      */
     @Getter
+    @Setter
     @LinkedIn
     private String staffCountRanges;
   }

--- a/src/main/java/com/echobox/api/linkedin/types/urn/URN.java
+++ b/src/main/java/com/echobox/api/linkedin/types/urn/URN.java
@@ -22,11 +22,15 @@ import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 /**
  * The type Urn.
  * @author clementcaylux 
  */
-public class URN {
+public class URN implements Serializable {
+  
+  private static final long serialVersionUID = -1L;
 
   @Getter
   @Setter
@@ -79,7 +83,7 @@ public class URN {
    *
    * @return the urn entity type
    */
-  public URNEntityType getURNEntityType() {
+  public URNEntityType resolveURNEntityType() {
     return URNEntityType.valueOf(entityType.toUpperCase());
   }
 


### PR DESCRIPTION
### Description of Changes

Adding setters and serialisation for `TargetAudience` class and all member classes. Also renaming the `getURNEntity` to `resolveUNREntity` to avoid using problems with json serialisation.

### Documentation

N/A

### Risks & Impacts

Small risk as it doesn't change any logic

### Testing

Tested locally with a webservice to make sure the TargetAudience field is converted to json.

