### PR TITLE
TEC-7345 Make OrganizationalTarget public

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/types/organization/AccessControl.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/AccessControl.java
@@ -73,7 +73,7 @@ public class AccessControl {
    * Organization target
    * @author Joanna
    */
-  private static class OrganizationalTarget {
+  public static class OrganizationalTarget {
     @Getter
     @LinkedIn
     private String localizedName;


### PR DESCRIPTION
### Description of Changes

- Make OrganizationalTarget public - doh!

### Documentation

https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api#retrieve-organizations

### Risks & Impacts

- Exposes OrganizationalTarget which should have been

### Testing

- Can call `OrganizationalTarget.getLocalizedName`
