### PR TITLE
TEC-7834 Update changeLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # ebx-linkedin-sdk Changelog
 
-## 0.1 (November 6, 2018)
+## 0.0.1 (November 6, 2018)
 
 * Initial release
 
-## 0.2 (July 22, 2019)
+## 1.0.2 (July 22, 2019)
 
 * Update incorrect spelling from UCG to UGC.
 * Update `DebugHeaderInfo.toString()` so it is more verbose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Initial release
 
+## 1.0.0 (March 29, 2019)
+
+## 1.0.1 (April 2, 2019)
+
 ## 1.0.2 (July 22, 2019)
 
 * Update incorrect spelling from UCG to UGC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,31 @@
 ## 0.1 (November 6, 2018)
 
 * Initial release
+
+## 0.2 (July 22, 2019)
+
+* Update incorrect spelling from UCG to UGC.
+* Update `DebugHeaderInfo.toString()` so it is more verbose.
+* Update `Organization.overviewPhotoV2` so it matches the LinkedIn
+  organization documentation.
+* Upload images bytes to LinkedIn for rich media uploads in addition to
+  files.
+* Update `TargetAudience.equals()`, `TargetAudience.hashcode()`,
+  `Locale.equals()` and `Locale.hashcode()` methods using Lombok
+  implementations.
+* `Locale` and `TargetAudience` have relevant setter methods.
+* Update method name `URN.getURNEntityType()` to
+  `URN.resolveURNEntityType()`
+* Add `Address.toString()` and `Locale.toString()` method.
+* Add constructor to URN to allow entity type to construct a URN object.
+* `OrganizationalTarget` class is public.
+* `TotalShareStatistics` class is public with relevant getters and
+  setters.
+* `ConnectionBaseV2.addTimeIntervalToParams()` checks for null time
+  interval.
+* Add `ImageV2Elements` to extend V2 images to support cropped images
+  (see:
+  https://developer.linkedin.com/docs/ref/v2/media-migration#migration)
+* Add `URNEntityType.UGCPost` and ensure all enums have the string
+  representation of the urn. Instead of using `URNEntityType.name()`
+  `URNEntityType.getEntityValue()` should be used to support UGCPosts.


### PR DESCRIPTION
### Description of Changes

- Update ChangeLog for releasing 1.0.2 to Maven Central

### Documentation

Not Applicable

### Risks & Impacts

- Releasing version 1.0.2 to Maven Central, however 1.0.2-SNAPSHOT has been used in production.

### Testing

- 1.0.2-SNAPSHOT has been used in production so seems to be working fine
