### PR TITLE
TEC-8021 Explicitly set build image values in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 sudo: false # faster builds
 
 # safelist


### PR DESCRIPTION
### Description of Changes

Explicitly set the distribution to use as the base image in the travis build.

### Documentation

See https://jira.echobox.com/browse/TEC-8021 for additional details

### Risks & Impacts

No additional risk.

### Testing

Build currently failing.  Explicitly setting distribution details, rather than rely on defaults, is ideal.  This PR will test this.

## Final Checklist

Please tick once completed.

- [X] Build passes.
- [X] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.