### PR TITLE
TEC-7956 Ensure non-error responses do not throw linkedin errors

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
@@ -604,8 +604,12 @@ public class DefaultLinkedInClient extends BaseLinkedInClient implements LinkedI
     
     String json = response.getBody();
     
-    // If the response contained an error code, throw an exception.
-    throwLinkedInResponseStatusExceptionIfNecessary(json, response.getStatusCode());
+    // If the response is 2XX then we do not need to throw an error response
+    if (HttpURLConnection.HTTP_OK != response.getStatusCode()
+        && HttpURLConnection.HTTP_CREATED != response.getStatusCode()) {
+      // If the response contained an error code, throw an exception.
+      throwLinkedInResponseStatusExceptionIfNecessary(json, response.getStatusCode());
+    }
     
     // If there was no response error information and this was a 500
     // error, something weird happened on LinkedIn's end. Bail.

--- a/src/test/java/com/echobox/api/linkedin/client/DefaultLinkedInClientTest.java
+++ b/src/test/java/com/echobox/api/linkedin/client/DefaultLinkedInClientTest.java
@@ -33,18 +33,45 @@ import java.security.GeneralSecurityException;
 public class DefaultLinkedInClientTest {
   
   /**
+   * Test 401 error with unparsable JSON body throws a LinkedInOauthException
+   * @throws GeneralSecurityException GeneralSecurityException
+   * @throws IOException IOException
+   */
+  @Test
+  public void test200Response()
+      throws GeneralSecurityException, IOException {
+    DefaultLinkedInClient client = new DefaultLinkedInClient("test");
+    WebRequestor.Response response =
+        client.makeRequestAndProcessResponse(() -> new WebRequestor.Response(200, null, null));
+  }
+  
+  /**
+   * Test 401 error with unparsable JSON body throws a LinkedInOauthException
+   * @throws GeneralSecurityException GeneralSecurityException
+   * @throws IOException IOException
+   */
+  @Test
+  public void test201Response()
+      throws GeneralSecurityException, IOException {
+    DefaultLinkedInClient client = new DefaultLinkedInClient("test");
+    WebRequestor.Response response =
+        client.makeRequestAndProcessResponse(() -> new WebRequestor.Response(201, null, null));
+    Assert.assertEquals(HttpURLConnection.HTTP_CREATED, response.getStatusCode().intValue());
+  }
+  
+  /**
    * Test LinkedIn 401 error throws a LinkedInOauthException
    * @throws GeneralSecurityException GeneralSecurityException
    * @throws IOException IOException
    */
   @Test(expected = LinkedInOAuthException.class)
-  public void test401Error()
+  public void test401ResponseError()
       throws GeneralSecurityException, IOException {
     try {
       DefaultLinkedInClient client = new DefaultLinkedInClient("test");
       client.makeRequestAndProcessResponse(() -> new WebRequestor.Response(401, null, "{"
-          + "\"message\": \"Empty oauth2_access_token\","
-          + "\"serviceErrorCode\": 401,\"status\": 401" + "}"));
+          + "\"message\": \"Empty oauth2_access_token\",\"serviceErrorCode\": 401,"
+          + "\"status\": 401}"));
     } catch (LinkedInOAuthException ex) {
       Assert.assertEquals("Empty oauth2_access_token", ex.getErrorMessage());
       Assert.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, ex.getHttpStatusCode().intValue());
@@ -58,7 +85,7 @@ public class DefaultLinkedInClientTest {
    * @throws IOException IOException
    */
   @Test(expected = LinkedInOAuthException.class)
-  public void test401ErrorNoJSON()
+  public void test401ResponseErrorNoJSON()
       throws GeneralSecurityException, IOException {
     try {
       DefaultLinkedInClient client = new DefaultLinkedInClient("test");


### PR DESCRIPTION
### Description of Changes

- Ensure non-error responses do not throw linkedin errors

### Documentation

Not Applicable

### Risks & Impacts

- Could fail to extract the response

### Testing

- Added additional unit tests
- Tested with snippet:
```
OrganizationConnection con = new OrganizationConnection(new DefaultLinkedInClient(authToken));
    Organization organization =
        con.retrieveOrganization(new URN("urn:li:organization:1234"), null);
```

## Final Checklist

Please tick once completed.

- [/] Build passes.
- [/] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [/] Change log has been updated.