### PR TITLE
TEC-7983 Content Length for post requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,5 +43,6 @@
 *  `DefaultLinkedInClient.throwLinkedInResponseStatusExceptionIfNecessary`
    should handle errors if they do not have an `error` attribute in the
    JSON.
-*  Add `Content-Lenght` for post requests in `DefaultWebRequester` 
+*  Add `Content-Lenght` for post requests in `DefaultWebRequester` (see: 
+   [Error handling](https://docs.microsoft.com/en-us/linkedin/shared/api-guide/concepts/error-handling))
    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,4 +43,5 @@
 *  `DefaultLinkedInClient.throwLinkedInResponseStatusExceptionIfNecessary`
    should handle errors if they do not have an `error` attribute in the
    JSON.
+*  Add `Content-Lenght` for post requests in `DefaultWebRequester` 
    

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -30,6 +30,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential.Builder;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.ByteArrayContent;
 import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpContent;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMediaType;
 import com.google.api.client.http.HttpRequest;
@@ -279,6 +280,10 @@ public class DefaultWebRequestor implements WebRequestor {
       // Allow subclasses to customize the connection if they'd like to - set their own headers,
       // timeouts, etc.
       customizeConnection(request);
+      
+      HttpContent content = request.getContent();
+      long length = (content != null) ? content.getLength() : 0;
+      httpHeaders.setContentLength(length);
   
       addHeadersToRequest(request, httpHeaders, headers);
 

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -31,7 +31,6 @@ import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.ByteArrayContent;
 import com.google.api.client.http.EmptyContent;
 import com.google.api.client.http.GenericUrl;
-import com.google.api.client.http.HttpContent;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMediaType;
 import com.google.api.client.http.HttpRequest;
@@ -58,7 +57,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.security.GeneralSecurityException;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -282,12 +280,6 @@ public class DefaultWebRequestor implements WebRequestor {
       // Allow subclasses to customize the connection if they'd like to - set their own headers,
       // timeouts, etc.
       customizeConnection(request);
-      
-      HttpContent content = request.getContent();
-      if (content == null) {
-        throw new IllegalStateException("The content of a post request cannot be null");
-      }
-      httpHeaders.setContentLength(content.getLength());
   
       addHeadersToRequest(request, httpHeaders, headers);
 

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -29,6 +29,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential.Builder;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.ByteArrayContent;
+import com.google.api.client.http.EmptyContent;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpContent;
 import com.google.api.client.http.HttpHeaders;
@@ -57,6 +58,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.security.GeneralSecurityException;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -271,7 +273,7 @@ public class DefaultWebRequestor implements WebRequestor {
           request.setResponseHeaders(new HttpHeaders().set(FORMAT_HEADER, "json"));
         } else {
           // Plain old POST request
-          request = requestFactory.buildPostRequest(genericUrl, null);
+          request = requestFactory.buildPostRequest(genericUrl, new EmptyContent());
         }
       }
 
@@ -282,8 +284,10 @@ public class DefaultWebRequestor implements WebRequestor {
       customizeConnection(request);
       
       HttpContent content = request.getContent();
-      long length = (content != null) ? content.getLength() : 0;
-      httpHeaders.setContentLength(length);
+      if (content == null) {
+        throw new IllegalStateException("The content of a post request cannot be null");
+      }
+      httpHeaders.setContentLength(content.getLength());
   
       addHeadersToRequest(request, httpHeaders, headers);
 


### PR DESCRIPTION
### Description of Changes

Getting the content length from the request and add the value in the `Content-Length` header. Zero will be added if no content is provided.


### Documentation
https://docs.microsoft.com/en-us/linkedin/shared/api-guide/concepts/error-handling?context=linkedin/context&trk=eml-mktg-20190826-developer-email-api-updates-august&mcid=6570277612550176769&src=e-eml#411-length-required

### Risks & Impacts

A small potential risk is the case where the content length is negative (-1). This indicates that at this point we can't know the length. I have tried to share a post with content length -1 and it worked ok. 

### Testing

Manually posted share and checked the field was set. In staging we should try to update a page to check post with empty content
```java
public static void main(String[] args) throws GeneralSecurityException, IOException {
    DefaultWebRequestor requestor = new DefaultWebRequestor("test");
  
    Response response = requestor.executePost("http://www.test.com", "test=test", null);
    
    response.getBody();
  }
```

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.