### PR TITLE
TEC-7950 Ensure 204 HTTP_NO_CONTENT is not thrown as an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,4 +45,8 @@
    JSON.
 *  Add `Content-Lenght` for post requests in `DefaultWebRequester` (see: 
    [Error handling](https://docs.microsoft.com/en-us/linkedin/shared/api-guide/concepts/error-handling))
+* Ensure HTTP status 204 (No Content) does not throw a
+  `LinkedInException` as it's returned by `DELETE
+  https://api.linkedin.com/v2/ugcPosts/{encoded ugcPostUrn|shareUrn}`
+  [Delete UGC Posts](https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#delete-ugc-posts).
    

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
@@ -623,6 +623,7 @@ public class DefaultLinkedInClient extends BaseLinkedInClient implements LinkedI
     // throw an exception.
     if (HttpURLConnection.HTTP_OK != response.getStatusCode()
         && HttpURLConnection.HTTP_CREATED != response.getStatusCode()
+        && HttpURLConnection.HTTP_NO_CONTENT != response.getStatusCode()
         && HttpURLConnection.HTTP_BAD_REQUEST != response.getStatusCode()
         && HttpURLConnection.HTTP_UNAUTHORIZED != response.getStatusCode()
         && HttpURLConnection.HTTP_NOT_FOUND != response.getStatusCode()
@@ -638,7 +639,8 @@ public class DefaultLinkedInClient extends BaseLinkedInClient implements LinkedI
     
     // If the response is 2XX then we do not need to throw an error response
     if (HttpURLConnection.HTTP_OK != response.getStatusCode()
-        && HttpURLConnection.HTTP_CREATED != response.getStatusCode()) {
+        && HttpURLConnection.HTTP_CREATED != response.getStatusCode()
+        && HttpURLConnection.HTTP_NO_CONTENT != response.getStatusCode()) {
       // If the response contained an error code, throw an exception.
       throwLinkedInResponseStatusExceptionIfNecessary(json, response.getStatusCode());
     }

--- a/src/test/java/com/echobox/api/linkedin/client/DefaultLinkedInClientTest.java
+++ b/src/test/java/com/echobox/api/linkedin/client/DefaultLinkedInClientTest.java
@@ -33,7 +33,7 @@ import java.security.GeneralSecurityException;
 public class DefaultLinkedInClientTest {
   
   /**
-   * Test 401 error with unparsable JSON body throws a LinkedInOauthException
+   * Test 200 response status does not throw a LinkedInOauthException
    * @throws GeneralSecurityException GeneralSecurityException
    * @throws IOException IOException
    */
@@ -46,7 +46,7 @@ public class DefaultLinkedInClientTest {
   }
   
   /**
-   * Test 401 error with unparsable JSON body throws a LinkedInOauthException
+   * Test 202 response status does not throw a LinkedInOauthException
    * @throws GeneralSecurityException GeneralSecurityException
    * @throws IOException IOException
    */
@@ -57,6 +57,20 @@ public class DefaultLinkedInClientTest {
     WebRequestor.Response response =
         client.makeRequestAndProcessResponse(() -> new WebRequestor.Response(201, null, null));
     Assert.assertEquals(HttpURLConnection.HTTP_CREATED, response.getStatusCode().intValue());
+  }
+  
+  /**
+   * Test 204 response status does not throw a LinkedInOauthException
+   * @throws GeneralSecurityException GeneralSecurityException
+   * @throws IOException IOException
+   */
+  @Test
+  public void test204Response()
+      throws GeneralSecurityException, IOException {
+    DefaultLinkedInClient client = new DefaultLinkedInClient("test");
+    WebRequestor.Response response =
+        client.makeRequestAndProcessResponse(() -> new WebRequestor.Response(204, null, null));
+    Assert.assertEquals(HttpURLConnection.HTTP_NO_CONTENT, response.getStatusCode().intValue());
   }
   
   /**


### PR DESCRIPTION
### Description of Changes

- Ensure 204 HTTP_NO_CONTENT is not thrown as an error

### Documentation

Not Applicable

### Risks & Impacts

- Will not throw an error if 204 http response is returned (but it shouldn't...)

### Testing

- Added a unit test
- Tested by deleting a UCG Post:
```
UGCShareConnection con = new UGCShareConnection(new DefaultLinkedInClient(authToken,
        Version.DEFAULT_VERSION));
con.deleteUGCPost(new URN("urn:li:share:12334"));
```

## Final Checklist

Please tick once completed.

- [X] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [X] Change log has been updated.