### PR TITLE
TEC-8790 Add new ShareMediaCategory 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,4 +54,5 @@
   videos. LinkedIn is planning to deprecate the existing Rich Media 
   Platform by `Janurary 30, 2020`.
   See [migration guide](https://docs.microsoft.com/en-us/linkedin/shared/references/migrations/rich-media-platform-deprecation?context=linkedin/marketing/context&trk=eml-mktg-20191028-developer-email-api-updates-october&mcid=6592215409070530560&src=e-eml).
+* Add `NATIVE_DOCUMENT`, `URN_REFERENCE`, `LIVE_VIDEO` to UGC ShareMediaCategory enum.
    

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ShareMediaCategory.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ShareMediaCategory.java
@@ -74,9 +74,27 @@ public enum ShareMediaCategory {
   CAROUSEL,
   
   /**
-   *    * Represents shared content of various types that should be rendered in carousel format
-   *    .Represents shared content that only contains topics.
+   * Represents shared content that only contains topics.
    */
-  TOPIC;
+  TOPIC,
+  
+  /**
+   * Represents shared content of document file types that are uploaded natively.
+   */
+  NATIVE_DOCUMENT,
+  
+  /**
+   * Refer to the media urn for the category of the content, except when urn type is digital media
+   * asset because this urn type does not expose the content type. Use mediaType in ShareMedia
+   * when disambiguation is required.
+   */
+  URN_REFERENCE,
+  
+  /**
+   * Represents shared content of a video that is streamed live. This means that the ugcPost may
+   * be consumed during recording. The resource serving the media is the source of truth for
+   * whether the video is currently live.
+   */
+  LIVE_VIDEO;
 
 }


### PR DESCRIPTION


### Description of Changes

- Add new ShareMediaCategory NATIVE_DOCUMENT, URN_REFERENCE, LIVE_VIDEO

### Documentation

[LinkedIn documentation](https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api)

### Risks & Impacts

- Should support more types of ShareMediaCategory enums

### Testing

- Added additional enums and ensure we support LIVE_VIDEO

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.