### PR TITLE
TEC-9746 Interim fix for Linkedin API pagingation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,4 +57,10 @@
 * Add `NATIVE_DOCUMENT`, `URN_REFERENCE`, `LIVE_VIDEO` to UGC ShareMediaCategory enum.
 * Checkstyle plugin version bumped. Some code reformatted in order to satisfy new checkstyle rules.
 
-## 1.0.4 (Work in progress)
+## 1.0.4
+* Put in a place an interim fix for Linkedin V2 pagingation. It seems like LinkedIn's pagination 
+is incorrectly returning the number of elements where the number of elements is less than the 
+request amount even though there are are in fact more more results. This fix should continue to 
+the next page until there are no more results.
+
+## 1.0.5 (Work in progress)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
 </dependency>
 ```
 

--- a/src/main/java/com/echobox/api/linkedin/client/paging/V2PagingImpl.java
+++ b/src/main/java/com/echobox/api/linkedin/client/paging/V2PagingImpl.java
@@ -53,16 +53,26 @@ public class V2PagingImpl extends PagingStrategy {
           // You will know that you have reached the end of the dataset when your response
           // contains less elements in the entities block of the response than your count
           // parameter requested.
-          Map<String, List<String>> extractParametersFromUrl =
-              URLUtils.extractParametersFromUrl(fullEndpoint);
-          if (extractParametersFromUrl.containsKey("count")) {
-            // Check if the count is less than the elements returned - if so we're at the last page
-            int requestedCount = Integer.parseInt(extractParametersFromUrl.get("count").get(0));
-            if (elements.size() < requestedCount) {
-              nextPageUrl = null;
-              setPreviousPageURL(fullEndpoint, start, count);
-              return;
-            }
+//          Map<String, List<String>> extractParametersFromUrl =
+//              URLUtils.extractParametersFromUrl(fullEndpoint);
+//          if (extractParametersFromUrl.containsKey("count")) {
+//            // Check if the count is less than the elements returned - if so we're at the last page
+//            int requestedCount = Integer.parseInt(extractParametersFromUrl.get("count").get(0));
+//            if (elements.size() <= requestedCount) {
+//              nextPageUrl = null;
+//              setPreviousPageURL(fullEndpoint, start, count);
+//              return;
+//            }
+//          }
+  
+          // LinkedIn paging seems to be currently broken and it might return return elements
+          // where the count is less than the number of items requested but in fact there are
+          // more elements and LinkedIn API has not returned them. Instead, continue to explore
+          // the next page until there are no more pages.
+          if (elements.size() <= 0) {
+            nextPageUrl = null;
+            setPreviousPageURL(fullEndpoint, start, count);
+            return;
           }
 
           // Paging is available

--- a/src/main/java/com/echobox/api/linkedin/client/paging/V2PagingImpl.java
+++ b/src/main/java/com/echobox/api/linkedin/client/paging/V2PagingImpl.java
@@ -17,12 +17,8 @@
 
 package com.echobox.api.linkedin.client.paging;
 
-import com.echobox.api.linkedin.util.URLUtils;
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * The paging strategy for V1 JSON responses
@@ -56,7 +52,7 @@ public class V2PagingImpl extends PagingStrategy {
 //          Map<String, List<String>> extractParametersFromUrl =
 //              URLUtils.extractParametersFromUrl(fullEndpoint);
 //          if (extractParametersFromUrl.containsKey("count")) {
-//            // Check if the count is less than the elements returned - if so we're at the last page
+            // Check if the count is less than the elements returned - if so we're at the last page
 //            int requestedCount = Integer.parseInt(extractParametersFromUrl.get("count").get(0));
 //            if (elements.size() <= requestedCount) {
 //              nextPageUrl = null;

--- a/src/test/java/com/echobox/api/linkedin/client/paging/V2PagingImplTest.java
+++ b/src/test/java/com/echobox/api/linkedin/client/paging/V2PagingImplTest.java
@@ -52,7 +52,7 @@ public class V2PagingImplTest {
   }
   
   /**
-   *Test providing
+   * Test pagination should stop if there are no more elements returned in the response
    */
   @Test
   public void testNoElementsShouldReturnNullNextPrevURLs() {

--- a/src/test/java/com/echobox/api/linkedin/client/paging/V2PagingImplTest.java
+++ b/src/test/java/com/echobox/api/linkedin/client/paging/V2PagingImplTest.java
@@ -57,7 +57,8 @@ public class V2PagingImplTest {
   @Test
   public void testNoElementsShouldReturnNullNextPrevURLs() {
     PagingStrategy strategy = new V2PagingImpl();
-    strategy.populatePages(Json.parse("{\"paging\":{\"count\":5,\"start\":0},\"elements\":[]}").asObject(),
+    strategy.populatePages(Json.parse("{\"paging\":{\"count\":5,\"start\":0},\"elements\":[]}")
+            .asObject(),
         "https://test.com/test");
     assertNull(strategy.getNextPageUrl());
     assertNull(strategy.getPreviousPageUrl());

--- a/src/test/java/com/echobox/api/linkedin/client/paging/V2PagingImplTest.java
+++ b/src/test/java/com/echobox/api/linkedin/client/paging/V2PagingImplTest.java
@@ -52,19 +52,31 @@ public class V2PagingImplTest {
   }
   
   /**
-   * Test if the provided count in the URL is greater than the number of elements returned then we
-   * have reached the last page
-   * There is not previous page URL as the start is at 0
+   *Test providing
    */
   @Test
-  public void testNextAndPrevURLsAreBothNull() {
+  public void testNoElementsShouldReturnNullNextPrevURLs() {
     PagingStrategy strategy = new V2PagingImpl();
-    strategy.populatePages(
-        Json.parse("{\"paging\":{\"count\":5,\"start\":0},\"elements\":[1]}").asObject(),
-        "https://test.com/test?start=10&count=5");
+    strategy.populatePages(Json.parse("{\"paging\":{\"count\":5,\"start\":0},\"elements\":[]}").asObject(),
+        "https://test.com/test");
     assertNull(strategy.getNextPageUrl());
     assertNull(strategy.getPreviousPageUrl());
   }
+  
+//  /**
+//   * Test if the provided count in the URL is greater than the number of elements returned then we
+//   * have reached the last page
+//   * There is not previous page URL as the start is at 0
+//   */
+//  @Test
+//  public void testNextAndPrevURLsAreBothNull() {
+//    PagingStrategy strategy = new V2PagingImpl();
+//    strategy.populatePages(
+//        Json.parse("{\"paging\":{\"count\":5,\"start\":0},\"elements\":[1]}").asObject(),
+//        "https://test.com/test?start=10&count=5");
+//    assertNull(strategy.getNextPageUrl());
+//    assertNull(strategy.getPreviousPageUrl());
+//  }
   
   /**
    * If the start = 0, there should be no previous page URL available
@@ -93,18 +105,18 @@ public class V2PagingImplTest {
     assertEquals("https://test.com/test?start=0&count=5", strategy.getPreviousPageUrl());
   }
   
-  /**
-   * If the requested count > the number of elements, there next page URL should be null
-   * If the start != 0, there should be a previous page URL with no overlap
-   */
-  @Test
-  public void testNextURLIsNullAndPrevURLsAvailable() {
-    PagingStrategy strategy = new V2PagingImpl();
-    strategy.populatePages(
-        Json.parse("{\"paging\":{\"count\":5,\"start\":15},\"elements\":[1]}").asObject(),
-        "https://test.com/test?start=5&count=5");
-    assertNull(strategy.getNextPageUrl());
-    assertEquals("https://test.com/test?start=10&count=5", strategy.getPreviousPageUrl());
-  }
+//  /**
+//   * If the requested count > the number of elements, there next page URL should be null
+//   * If the start != 0, there should be a previous page URL with no overlap
+//   */
+//  @Test
+//  public void testNextURLIsNullAndPrevURLsAvailable() {
+//    PagingStrategy strategy = new V2PagingImpl();
+//    strategy.populatePages(
+//        Json.parse("{\"paging\":{\"count\":5,\"start\":15},\"elements\":[1]}").asObject(),
+//        "https://test.com/test?start=5&count=5");
+//    assertNull(strategy.getNextPageUrl());
+//    assertEquals("https://test.com/test?start=10&count=5", strategy.getPreviousPageUrl());
+//  }
 
 }


### PR DESCRIPTION
### Description of Changes

- Currently LinkedIn API is returning an incorrect number of elements for paginated results. For example there are 15 elements, with an initial size of 10, however LinkedIn has returned 8 results. An interim fix for this would be to continue to the next page until there are no more elements in the result.

### Documentation

https://docs.microsoft.com/en-us/linkedin/shared/api-guide/concepts/pagination?context=linkedin/marketing/context

### Risks & Impacts

- Pagination is a core part of the LinkedIn API and affects all responses that are paginated.

### Testing

- Ran this snippet:
```
OrganizationConnection con = new OrganizationConnection(new DefaultLinkedInClient(authToken));
    List<AccessControl> organization = con.fetchMemberOrganizationAccessControl(null,
        null, null, null);
```

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.