### PR TITLE
TEC-10202 Ensure retrieving UGC are optionally sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,4 +76,8 @@ parameter is provided in the initial request, `V2PaginationImpl` will continue t
 all pages until the number of elements in the response no longer equals the expected count. 
 This will avoid infinitely looping over pages until an empty page is discovered.
 
-## 1.0.7 (Work in progress)
+## 1.0.7 (September 17, 2020)
+* UGCShareConnection.retrieveUGCPostsByAuthors() now includes sortBy param to get posts
+sorted by creation date.
+
+## 1.0.8 (Work in progress)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>validate</id>
@@ -190,7 +190,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.18</version>
+            <version>8.29</version>
           </dependency>
           <dependency>
             <groupId>com.github.sevntu-checkstyle</groupId>
@@ -226,20 +226,6 @@
             <configuration>
               <printFailingErrors>true</printFailingErrors>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>

--- a/src/main/java/com/echobox/api/linkedin/connection/ConnectionBase.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/ConnectionBase.java
@@ -20,6 +20,7 @@ package com.echobox.api.linkedin.connection;
 import com.echobox.api.linkedin.client.Connection;
 import com.echobox.api.linkedin.client.LinkedInClient;
 import com.echobox.api.linkedin.client.Parameter;
+import com.echobox.api.linkedin.types.UGCPostsSortBy;
 import com.echobox.api.linkedin.types.urn.URN;
 import com.echobox.api.linkedin.types.urn.URNEntityType;
 import com.echobox.api.linkedin.util.ValidationUtils;
@@ -120,6 +121,18 @@ public abstract class ConnectionBase {
     }
     if (count != null) {
       params.add(Parameter.with("count", count));
+    }
+  }
+  
+  /**
+   * Add sortBy parameter
+   *
+   * @param params the list of parameters
+   * @param sortBy how the posts should be sorted in the response
+   */
+  protected void addSortByParam(List<Parameter> params, UGCPostsSortBy sortBy) {
+    if (sortBy != null) {
+      params.add(Parameter.with("sortBy", sortBy.toString()));
     }
   }
 

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/UGCShareConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/UGCShareConnection.java
@@ -20,6 +20,7 @@ package com.echobox.api.linkedin.connection.v2;
 import com.echobox.api.linkedin.client.Connection;
 import com.echobox.api.linkedin.client.LinkedInClient;
 import com.echobox.api.linkedin.client.Parameter;
+import com.echobox.api.linkedin.types.UGCPostsSortBy;
 import com.echobox.api.linkedin.types.ugc.UGCShare;
 import com.echobox.api.linkedin.types.ugc.ViewContext;
 import com.echobox.api.linkedin.types.urn.URN;
@@ -99,6 +100,7 @@ public class UGCShareConnection extends ConnectionBaseV2 {
     parameters.add(Parameter.with(QUERY_KEY, AUTHORS));
     addParametersFromURNs(parameters, AUTHORS, Arrays.asList(authorURN));
     addStartAndCountParams(parameters, null, count);
+    addSortByParam(parameters, UGCPostsSortBy.CREATED);
     return linkedinClient.fetchConnection(UGC_POST, UGCShare.class,
         parameters.toArray(new Parameter[parameters.size()]));
   }

--- a/src/main/java/com/echobox/api/linkedin/types/UGCPostsSortBy.java
+++ b/src/main/java/com/echobox/api/linkedin/types/UGCPostsSortBy.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types;
+
+/**
+ * How UGC posts should be sorted when retrieved
+ * @author Christopher Lyall
+ *
+ */
+public enum UGCPostsSortBy {
+  
+  /**
+   * Sorted in descending order by creation date
+   */
+  CREATED,
+  
+  /**
+   * Sorted in descending order by last modified date
+   */
+  LAST_MODIFIED;
+}


### PR DESCRIPTION
### Description of Changes
Added sortBy parameter to request to retrieve UGC posts.

### Documentation
None.

### Risks & Impacts
Sort order of posts returned might be affected, but should remain constant.

### Testing
Untested for the moment, as there are no unit tests that actually use this code path, so probably best to test when using the updated sdk on main.

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.