### PR TITLE
GH-119 convert supportedUploadMechanism to List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,4 +90,5 @@ sorted by creation date.
 * Updated all dependencies. 
 * RemovedLinkedinLogger as EventLogger had been removed from slf4j-ext.
 
-## 2.0.1 (Work in Progress)
+## 2.0.1 (Jan 13, 2020)
+* Change `RegisterUploadRequestBody.supportedUploadMechanism` from `SupportedUploadMechanism ` to `List< SupportedUploadMechanism >`

--- a/src/main/java/com/echobox/api/linkedin/types/assets/RegisterUploadRequestBody.java
+++ b/src/main/java/com/echobox/api/linkedin/types/assets/RegisterUploadRequestBody.java
@@ -65,7 +65,7 @@ public class RegisterUploadRequestBody {
     @Getter
     @Setter
     @LinkedIn
-    private SupportedUploadMechanism supportedUploadMechanism;
+    private List<SupportedUploadMechanism> supportedUploadMechanism;
   
     /**
      * Size in bytes

--- a/src/test/java/com/echobox/api/linkedin/types/assets/RegisterUploadRequestBodyTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/assets/RegisterUploadRequestBodyTest.java
@@ -32,13 +32,23 @@ public class RegisterUploadRequestBodyTest {
 
   @Test
   public void testRegisterUploadRequestBody() {
-    String json = "{\n" + "    \"registerUploadRequest\": {\n"
-        + "        \"owner\": \"urn:li:organization:10000\",\n" + "        \"recipes\": [\n"
-        + "            \"urn:li:digitalmediaRecipe:feedshare-video\"\n" + "        ],\n"
-        + "        \"serviceRelationships\": [\n" + "            {\n"
+    String json = "{\n"
+        + "    \"registerUploadRequest\": {\n"
+        + "        \"owner\": \"urn:li:organization:10000\",\n"
+        + "        \"recipes\": [\n"
+        + "            \"urn:li:digitalmediaRecipe:feedshare-video\"\n"
+        + "        ],\n"
+        + "        \"serviceRelationships\": [\n"
+        + "            {\n"
         + "                \"identifier\": \"urn:li:userGeneratedContent\",\n"
-        + "                \"relationshipType\": \"OWNER\"\n" + "            }\n" + "        ]\n"
-        + "    }\n" + "}";
+        + "                \"relationshipType\": \"OWNER\"\n"
+        + "            }\n"
+        + "        ],\n"
+        + "        \"supportedUploadMechanism\":[\n"
+        + "            \"SINGLE_REQUEST_UPLOAD\"\n"
+        + "        ]\n"
+        + "    }\n"
+        + "}";
   
     DefaultJsonMapper defaultJsonMapper = new DefaultJsonMapper();
     RegisterUploadRequestBody registerUploadRequestBody =
@@ -60,6 +70,12 @@ public class RegisterUploadRequestBodyTest {
     Assert.assertEquals("urn:li:userGeneratedContent",
         serviceRelationships.get(0).getIdentifier());
     Assert.assertEquals(RelationshipType.OWNER, serviceRelationships.get(0).getRelationshipType());
+
+    List<RegisterUploadRequestBody.SupportedUploadMechanism> supportedUploadMechanism =
+            registerUploadRequest.getSupportedUploadMechanism();
+    Assert.assertEquals(1, supportedUploadMechanism.size());
+    Assert.assertEquals(RegisterUploadRequestBody.SupportedUploadMechanism.SINGLE_REQUEST_UPLOAD,
+            supportedUploadMechanism.get(0));
   }
 
 }


### PR DESCRIPTION
### Description of Changes
- Changed `RegisterUploadRequestBody.supportedUploadMechanism` from `SupportedUploadMechanism ` to `List< SupportedUploadMechanism >`
- Change the deserialization of list to support enums

### Documentation
See https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/vector-asset-api#register-an-upload-for-images

### Risks & Impacts

- May impact deserialization from JSON

### Testing

- Add unit tests

### Compare (For layered PRs)

N/A

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.