### PR TITLE
GH-123 Fixed unable to obtain accessToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,4 +96,3 @@ sorted by creation date.
 ## 2.0.2 (April 23, 2021)
 * Add `application/x-wwww-form-urlenconded` header to obtain access token request and update additional header method to add headers as a list.
 
-## 2.0.3 (Work in Progress)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,4 +93,7 @@ sorted by creation date.
 ## 2.0.1 (Jan 13, 2020)
 * Change `RegisterUploadRequestBody.supportedUploadMechanism` from `SupportedUploadMechanism ` to `List< SupportedUploadMechanism >`
 
-## 2.0.1 (Work in Progress)
+## 2.0.2 (April 23, 2021)
+* Add `application/x-wwww-form-urlenconded` header to obtain access token request and update additional header method to add headers as a list.
+
+## 2.0.3 (Work in Progress)

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
@@ -50,6 +50,7 @@ import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -339,9 +340,12 @@ public class DefaultLinkedInClient extends BaseLinkedInClient implements LinkedI
 
     try {
       this.webRequestor = new DefaultWebRequestor(appId, appSecret);
+  
+      Map<String, String> headers = new HashMap<>();
+      headers.put("Content-Type", "application/x-www-form-urlencoded");
 
-      final String response = makeRequestFull(ENDPOINT_ACCESS_TOKEN, true, false, new JsonObject(),
-          null, Collections.emptyList(), Parameter.with(GRANT_TYPE_PARAM_NAME,
+      final String response = makeRequestFull(ENDPOINT_ACCESS_TOKEN, true, false, null,
+          headers, Collections.emptyList(), Parameter.with(GRANT_TYPE_PARAM_NAME,
           "authorization_code"),
           Parameter.with(CODE_PARAM_NAME, verificationCode),
           Parameter.with(REDIRECT_URI_PARAM_NAME, redirectUri),

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -55,7 +55,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.security.GeneralSecurityException;
-import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -630,13 +629,16 @@ public class DefaultWebRequestor implements WebRequestor {
     return new JsonHttpContent(new GsonFactory(), map);
   }
   
-  private void addHeadersToRequest(HttpRequest request, HttpHeaders httpHeaders,
-      Map<String, String> headers) {
+  private void addHeadersToRequest(HttpRequest request, HttpHeaders httpHeaders, Map<String, String> headers) {
     if (headers != null) {
       // Add any additional headers
-      for (String headerKey : headers.keySet()) {
-        httpHeaders.putIfAbsent(headerKey, Collections.singletonList(headers.get(headerKey)));
-      }
+        headers.entrySet()
+                .stream()
+                .filter(headerEntry -> {
+                  String lowerCaseHeaderName = headerEntry.getKey().toLowerCase();
+                  return !httpHeaders.containsKey(lowerCaseHeaderName);
+                })
+                .forEach(headerEntry -> httpHeaders.put(headerEntry.getKey(), headerEntry.getValue()));
     }
   
     request.setHeaders(httpHeaders);

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -55,6 +55,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.security.GeneralSecurityException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -634,9 +635,7 @@ public class DefaultWebRequestor implements WebRequestor {
     if (headers != null) {
       // Add any additional headers
       for (String headerKey : headers.keySet()) {
-        if (!headerKey.equalsIgnoreCase("content-type")) {
-          httpHeaders.put(headerKey, headers.get(headerKey));
-        }
+        httpHeaders.putIfAbsent(headerKey, Collections.singletonList(headers.get(headerKey)));
       }
     }
   


### PR DESCRIPTION
### Description of Changes

Instead of providing an empty JSON object as the body of the request, we are setting it to null. This ensures that no content type is set by `DefaultWebRequestor::executePost`. I also changed the `DefaultWebRequestor::addHeadersToRequest` to allow to set `application/x-www-form-urlencoded` value for `Content-Type` header (if it has not been set yet).

Note: Although the [documentation](https://docs.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin%2Fcontext&tabs=HTTPS#step-3-exchange-authorization-code-for-an-access-token) suggests that you need to add a Content-Type header, the request still works without it. I have added the header to comply with the documentation and just in case it stops working in future because the header is missing.

### Documentation

Not Applicable.

### Risks & Impacts

- If anything breaks it should only affect the ability to retrieve the user access token (which is currently broken, but this fixes it).
- The changes are fairly simple and minor, rolling back should be fairly straightforward.

### Testing

I have manually run the code below by providing a valid app id, secret, uri and code.

```
DefaultLinkedInClient client = new DefaultLinkedInClient(Version.DEFAULT_VERSION);
LinkedInClient.AccessToken accessToken = client.obtainUserAccessToken(appId, appSecret, redirectUri, verificationCode);
LOGGER.info(accessToken.getAccessToken());
```
## Version
I believe that just bumping the version to 2.0.2 is fine, since it isn't a major change.

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.