### PR TITLE
GH-239 fix getShares method

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/connection/v2/ShareConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/ShareConnection.java
@@ -59,25 +59,24 @@ public class ShareConnection extends ConnectionBaseV2 {
   public Share getShare(long shareId) {
     return linkedinClient.fetchObject(SHARES + "/" + shareId, Share.class);
   }
-  
+
   /**
    * Retrieve the collection of shares owned by a specific member or organization. Use URNs
    * formatted as urn:li:person:{id} , urn:li:organization:{id} , or urn:li:organizationBrand:{id}
    * to retrieve shares for the relevant entity.
    * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/share-api#retrieve-shares">
    * Retrieve Shares</a>
-   * @param ownerURNs the URNs of the owner
+   * @param ownerURN the URN of the owner
    * @param sharesPerOwner the number of shares per owner
    * @param count the number of entries to be returned per paged request
    * @return the share corresponding to the share id
    */
-  public List<Share> getShares(List<URN> ownerURNs, int sharesPerOwner, Integer count) {
+  public List<Share> getShares(URN ownerURN, int sharesPerOwner, Integer count) {
     List<Parameter> params = new ArrayList<>();
   
     params.add(Parameter.with(QUERY_KEY, OWNERS));
-    addParametersFromURNs(params, SHARES_PARAM, ownerURNs);
+    params.add(Parameter.with(OWNERS, ownerURN));
     params.add(Parameter.with(SHARES_PER_OWNER, sharesPerOwner));
-    params.add(Parameter.with(COUNT, 20));
     addStartAndCountParams(params, null, count);
     
     return getListFromQuery(SHARES, Share.class, params.toArray(new Parameter[0]));

--- a/src/main/java/com/echobox/api/linkedin/types/social/actions/CommentAction.java
+++ b/src/main/java/com/echobox/api/linkedin/types/social/actions/CommentAction.java
@@ -18,6 +18,7 @@
 package com.echobox.api.linkedin.types.social.actions;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import com.echobox.api.linkedin.types.objectype.AuditStamp;
 import com.echobox.api.linkedin.types.urn.ContainsURN;
 import com.echobox.api.linkedin.types.urn.URN;
 import lombok.Getter;
@@ -65,6 +66,16 @@ public class CommentAction extends ContainsURN {
   @Setter
   @LinkedIn
   private URN object;
+
+  @Getter
+  @Setter
+  @LinkedIn
+  private AuditStamp created;
+
+  @Getter
+  @Setter
+  @LinkedIn
+  private AuditStamp lastModified;
   
   /**
    * A Model to describe the content of a comment


### PR DESCRIPTION
### Description of Changes

This pull requests removes the duplicate count parameter and fixes the owner URNs array param, since they original, unmodified method returned status 403.

### Documentation
[Find shares by owner](https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/share-api?tabs=http#find-shares-by-owner)

### Risks & Impacts

There should be no risks in my changes. Impact should be very limited since the existing method doesn't work in the first place.

### Testing

Tests performed in local environment, with test calls. That's how I discovered the issue.

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.