### PR TITLE
TEC-15066 enable showcase as organisations for OrganizationConnection.retrieveOrganizationFollowerCount and OrgnizationConnection. retrieveShareStatistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,5 +97,7 @@ sorted by creation date.
 * Change `OrganizationConnection.fetchMemberOrganizationAccessControl` and `OrganizationConnection.findOrganizationAccessControl`
 to use `/OrganizationAcls` endpoint instead of `/OrganizationalEntityAcls` endpoint as the LinkedIn API will remove support for organisation entity ACLs  and replace it with organisation ACLs on October 30, 2021.
 
-## 3.0.1 (Work in progress)
+## 3.0.1 (Dec 2, 2021)
+* Ensure `OrganizationConnection.retrieveOrganizationFollowerCount` and `OrgnizationConnection. retrieveShareStatistics`
+can get data for both organization and organization brand pages.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1</version>
 </dependency>
 ```
 

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
@@ -203,7 +203,7 @@ public class OrganizationConnection extends ConnectionBaseV2 {
    * @return the number of followers for the organization
    */
   public Long retrieveOrganizationFollowerCount(URN organizationURN) {
-    validateOrganizationURN("organizationURN", organizationURN);
+    validateOrganizationOrBrandURN("organizationURN", organizationURN);
     NetworkSize networkSize = linkedinClient.fetchObject(NETWORK_SIZES + "/" + organizationURN,
         NetworkSize.class, Parameter.with(EDGE_TYPE, COMPANY_FOLLOWED_BY_MEMEBER));
     return networkSize.getFirstDegreeSize();
@@ -395,7 +395,7 @@ public class OrganizationConnection extends ConnectionBaseV2 {
    */
   public List<ShareStatistic> retrieveShareStatistics(URN organizationURN,
       TimeInterval timeInterval, List<URN> shareURNs, Integer count) {
-    validateOrganizationURN("organizationURN", organizationURN);
+    validateOrganizationOrBrandURN("organizationURN", organizationURN);
     
     List<Parameter> params = new ArrayList<>();
     params.add(Parameter.with(QUERY_KEY, ORGANIZATIONAL_ENTITY_KEY));
@@ -411,6 +411,15 @@ public class OrganizationConnection extends ConnectionBaseV2 {
     
     return getListFromQuery(SHARE_STATISTICS, ShareStatistic.class,
         params.toArray(new Parameter[0]));
+  }
+  
+  private void validateOrganizationOrBrandURN(String paramName, URN organizationOrBrandURN) {
+    ValidationUtils.verifyParameterPresence(paramName, organizationOrBrandURN);
+    if (!(URNEntityType.ORGANIZATION.equals(organizationOrBrandURN.resolveURNEntityType())
+        || URNEntityType.ORGANIZATIONBRAND.equals(organizationOrBrandURN.resolveURNEntityType()))) {
+      throw new IllegalArgumentException(String.format("The URN should be type %s or %s",
+          URNEntityType.ORGANIZATION, URNEntityType.ORGANIZATIONBRAND));
+    }
   }
 
   private void validateOrganizationURN(String paramName, URN organizationURN) {


### PR DESCRIPTION
### Description of Changes

- LinkedIn enables both organization and showcase pages to retrieve follower count and share statistics. Update the URN validation to enable `URNEntityType.ORGANIZATION` and `URNEntityType.ORGANIZATIONBRAND` to get the data.

### Documentation

- https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/share-statistics?tabs=http
- https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api?tabs=http#retrieve-organization-follower-count

### Risks & Impacts

- Will allow the API call to be made for both showcase and organisation pages

### Testing

- Tested locally:
```
LinkedInClient linkedInClient = new DefaultLinkedInClient(token, Version.V2);
    OrganizationConnection connection = new OrganizationConnection(linkedInClient);
    Long followerCount =
        connection.retrieveOrganizationFollowerCount([organization_or_brand_URN]);
    List<ShareStatistic> shareStatistics = connection.retrieveShareStatistics(urn, null,
        Arrays.asList([share_URN]), 10);
```
- Added both organisation and show case URNs as well as non-organisation URNs such as share URN

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.