### PR TITLE
TEC-15144 Update logging libraries 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,4 +101,9 @@ to use `/OrganizationAcls` endpoint instead of `/OrganizationalEntityAcls` endpo
 * Ensure `OrganizationConnection.retrieveOrganizationFollowerCount` and `OrgnizationConnection. retrieveShareStatistics`
 can get data for both organization and organization brand pages.
 
-## 3.0.2 (Work in progress)
+## 3.0.2 (Dec 20, 2021)
+* Update logback dependencies to move away from logback-classic and logback-core due to a 
+  security vulnerability. See [CVE-2017-5929](https://nvd.nist.gov/vuln/detail/CVE-2017-5929) 
+  for more information. Using ebx-structured logging instead.
+
+## 3.0.3 (Work in progress)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,6 @@ can get data for both organization and organization brand pages.
 ## 3.0.2 (Dec 20, 2021)
 * Update logback dependencies to move away from logback-classic and logback-core due to a 
   security vulnerability. See [CVE-2017-5929](https://nvd.nist.gov/vuln/detail/CVE-2017-5929) 
-  for more information. Using ebx-structured logging instead.
+  for more information. Using ebx-structured-logging instead.
 
 ## 3.0.3 (Work in progress)

--- a/pom.xml
+++ b/pom.xml
@@ -78,15 +78,9 @@
       <version>1.7.30</version>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback.contrib</groupId>
-      <artifactId>logback-json-classic</artifactId>
-      <version>0.1.5</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback.contrib</groupId>
-      <artifactId>logback-jackson</artifactId>
-      <version>0.1.5</version>
+      <groupId>com.echobox</groupId>
+      <artifactId>ebx-structuredlogging-sdk</artifactId>
+      <version>1.0.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### Description of Changes

- Move dependencies away from logback-classic and logback-core due to CVE-2017-5929. The dependency `ebx-structuredlogging-sdk` uses ``

### Documentation

https://ossindex.sonatype.org/vulnerability/391196a7-f007-430b-b47f-cd9a3fec6374?component-type=maven&component-name=ch.qos.logback.logback-classic&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0

### Risks & Impacts

Will update the logging libraries but there's no change in the logging structure after local testing

### Testing

Ran a local test to ensure logging format remains the same in both v3.0.1 and v3.0.2.
Ran `mvn dependency:tree` to make sure ogback-classic and logback-core 1.2.0 and previous is not used.

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.