### PR TITLE
TEC-16773 Update search by vanityName to return instances according to primaryOrganizationType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,4 +106,8 @@ can get data for both organization and organization brand pages.
   security vulnerability. See [CVE-2017-5929](https://nvd.nist.gov/vuln/detail/CVE-2017-5929) 
   for more information. Using ebx-structured-logging instead.
 
-## 3.0.3 (Work in progress)
+## 3.0.3 (Mar 25, 2022)
+* Update `findOrganizationByVanityName` to return `OrganizationBrand` if `primaryOrganizationType` is 
+  `BRAND`
+
+## 3.0.4 (Work in progress)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,8 @@ can get data for both organization and organization brand pages.
   for more information. Using ebx-structured-logging instead.
 
 ## 3.0.3 (Mar 25, 2022)
+* Add attribute `primaryOrganizationType` in OrganizationBase class
 * Update `findOrganizationByVanityName` to return `OrganizationBrand` if `primaryOrganizationType` is 
-  `BRAND`
+  `BRAND`.
 
 ## 3.0.4 (Work in progress)

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
@@ -36,7 +36,6 @@ import com.echobox.api.linkedin.util.ValidationUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -179,17 +178,13 @@ public class OrganizationConnection extends ConnectionBaseV2 {
     PrimaryOrganizationType targetType = organizationList.get(0).getPrimaryOrganizationType();
     List<? extends OrganizationBase> result;
     switch (targetType) {
-      case NONE:
-      case SCHOOL:
-        result = organizationList;
-        break;
       case BRAND:
         result = getListFromQuery(ORGANIZATIONS, OrganizationBrand.class,
             parameters.toArray(new Parameter[0]));
         break;
       default:
-        // Should not happen
-        result = Collections.emptyList();
+        // NONE or SCHOOL
+        result = organizationList;
     }
     return result;
   }

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
@@ -26,7 +26,7 @@ import com.echobox.api.linkedin.types.organization.NetworkSize;
 import com.echobox.api.linkedin.types.organization.Organization;
 import com.echobox.api.linkedin.types.organization.OrganizationBase;
 import com.echobox.api.linkedin.types.organization.OrganizationBrand;
-import com.echobox.api.linkedin.types.organization.PrimaryOrganizationType;
+import com.echobox.api.linkedin.types.organization.OrganizationResult;
 import com.echobox.api.linkedin.types.statistics.OrganizationFollowerStatistics;
 import com.echobox.api.linkedin.types.statistics.page.FollowerStatistic;
 import com.echobox.api.linkedin.types.statistics.page.Statistics;
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Organization connection class that should contain all organization operations
@@ -158,7 +159,7 @@ public class OrganizationConnection extends ConnectionBaseV2 {
    * @param count the number of entries to be returned per paged request
    * @return The organization with the vanity name
    */
-  public List<? extends OrganizationBase> findOrganizationByVanityName(String vanityName,
+  public List<OrganizationBase> findOrganizationByVanityName(String vanityName,
       Parameter fields, Integer count) {
     ValidationUtils.verifyParameterPresence("vanityName", vanityName);
   
@@ -169,24 +170,11 @@ public class OrganizationConnection extends ConnectionBaseV2 {
     parameters.add(Parameter.with(QUERY_KEY, VANITY_NAME_VALUE));
     parameters.add(Parameter.with(VANITY_NAME_KEY, vanityName));
     addStartAndCountParams(parameters, null, count);
-    List<Organization> organizationList = getListFromQuery(ORGANIZATIONS,
-        Organization.class, parameters.toArray(new Parameter[0]));
-    if (organizationList.size() == 0) {
-      return organizationList;
-    }
+    List<OrganizationResult> organizationList = getListFromQuery(ORGANIZATIONS,
+        OrganizationResult.class, parameters.toArray(new Parameter[0]));
     
-    PrimaryOrganizationType targetType = organizationList.get(0).getPrimaryOrganizationType();
-    List<? extends OrganizationBase> result;
-    switch (targetType) {
-      case BRAND:
-        result = getListFromQuery(ORGANIZATIONS, OrganizationBrand.class,
-            parameters.toArray(new Parameter[0]));
-        break;
-      default:
-        // NONE or SCHOOL
-        result = organizationList;
-    }
-    return result;
+    return organizationList.stream().map(OrganizationResult::getOrganization)
+        .collect(Collectors.toList());
   }
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
@@ -177,18 +177,21 @@ public class OrganizationConnection extends ConnectionBaseV2 {
     }
     
     PrimaryOrganizationType targetType = organizationList.get(0).getPrimaryOrganizationType();
-    if (PrimaryOrganizationType.NONE.equals(targetType)) {
-      // return the list if they are Organization
-      return organizationList;
-    } else if (PrimaryOrganizationType.BRAND.equals(targetType)) {
-      // Retrieve as OrganizationBrand
-      return getListFromQuery(ORGANIZATIONS, OrganizationBrand.class,
-          parameters.toArray(new Parameter[0]));
+    List<? extends OrganizationBase> result;
+    switch (targetType) {
+      case NONE:
+      case SCHOOL:
+        result = organizationList;
+        break;
+      case BRAND:
+        result = getListFromQuery(ORGANIZATIONS, OrganizationBrand.class,
+            parameters.toArray(new Parameter[0]));
+        break;
+      default:
+        // Should not happen
+        result = Collections.emptyList();
     }
-    
-    // Not supported for other organization types
-    return Collections.emptyList();
-    
+    return result;
   }
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/LinkedInIdAndURNType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/LinkedInIdAndURNType.java
@@ -20,6 +20,7 @@ package com.echobox.api.linkedin.types;
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 import com.echobox.api.linkedin.types.urn.URN;
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Linked in types that contain a URN field
@@ -29,6 +30,7 @@ import lombok.Getter;
 public abstract class LinkedInIdAndURNType extends LinkedInIdType {
   
   @Getter
+  @Setter
   @LinkedIn("$URN")
   private URN urn;
 

--- a/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationBase.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationBase.java
@@ -180,4 +180,12 @@ public abstract class OrganizationBase extends LinkedInIdAndURNType {
   @LinkedIn
   private CroppedImage logoV2;
   
+  /**
+   * Primary Organization type
+   */
+  @Getter
+  @Setter
+  @LinkedIn
+  private PrimaryOrganizationType primaryOrganizationType;
+  
 }

--- a/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationResult.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationResult.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.organization;
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Class for deserialising from Organization endpoint, which may return Organization or
+ * OrganizationBrand
+ * This class should contain all fields from Organization and OrganizationBrand
+ * @author Kenneth Wong
+ */
+public class OrganizationResult extends Organization {
+  
+  /**
+   * Admin-defined specialty tags of the entity.
+   */
+  @Getter
+  @Setter
+  @LinkedIn
+  private List<Specialty> tags;
+  
+  /**
+   * The URN of the entity's pinned post.
+   */
+  @Getter
+  @Setter
+  @LinkedIn
+  private String pinnedPost;
+  
+  
+  /**
+   * Whether the entity was auto-created.
+   */
+  @Getter
+  @Setter
+  @LinkedIn
+  private Boolean autoCreated;
+  
+  public OrganizationBase getOrganization() {
+    OrganizationBase result;
+    if (PrimaryOrganizationType.BRAND.equals(this.getPrimaryOrganizationType())) {
+      // OrganizationBrand
+      OrganizationBrand brand = new OrganizationBrand();
+      brand.setTags(this.getTags());
+      brand.setPinnedPost(this.getPinnedPost());
+      brand.setAutoCreated(this.getAutoCreated());
+      
+      result = brand;
+    } else {
+      // Organization
+      Organization organization = new Organization();
+      organization.setDeleted(this.getDeleted());
+      organization.setEntityStatus(this.getEntityStatus());
+      organization.setGroups(this.getGroups());
+      organization.setLocalizedWebsite(this.getLocalizedWebsite());
+      organization.setLocations(this.getLocations());
+      organization.setSpecialties(this.getSpecialties());
+      organization.setStaffCountRange(this.getStaffCountRange());
+      organization.setSchoolAttributes(this.getSchoolAttributes());
+      organization.setOverviewPhotoV2(this.getOverviewPhotoV2());
+      organization.setOrganizationType(this.getOrganizationType());
+
+      result = organization;
+    }
+    
+    // Common fields in OrganizationBase
+    result.setAlternativeNames(this.getAlternativeNames());
+    result.setCoverPhotoV2(this.getCoverPhotoV2());
+    result.setDefaultLocale(this.getDefaultLocale());
+    result.setDescription(this.getDescription());
+    result.setFoundedOn(this.getFoundedOn());
+    result.setLocalizedDescription(this.getLocalizedDescription());
+    result.setIndustries(this.getIndustries());
+    result.setLocalizedName(this.getLocalizedName());
+    result.setLocalizedSpecialties(this.getLocalizedSpecialties());
+    result.setName(this.getName());
+    result.setParentRelationship(this.getParentRelationship());
+    result.setVanityName(this.getVanityName());
+    result.setVersionTag(this.getVersionTag());
+    result.setWebsite(this.getWebsite());
+    result.setLogoV2(this.getLogoV2());
+    result.setPrimaryOrganizationType(this.getPrimaryOrganizationType());
+    
+    return result;
+  }
+}

--- a/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationResult.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationResult.java
@@ -100,6 +100,7 @@ public class OrganizationResult extends Organization {
     result.setWebsite(this.getWebsite());
     result.setLogoV2(this.getLogoV2());
     result.setPrimaryOrganizationType(this.getPrimaryOrganizationType());
+    result.setId(this.getId());
     
     return result;
   }

--- a/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationResult.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationResult.java
@@ -77,7 +77,9 @@ public class OrganizationResult extends Organization {
       organization.setSpecialties(this.getSpecialties());
       organization.setStaffCountRange(this.getStaffCountRange());
       organization.setSchoolAttributes(this.getSchoolAttributes());
+      organization.setOverviewPhoto(this.getOverviewPhoto());
       organization.setOverviewPhotoV2(this.getOverviewPhotoV2());
+      organization.setOrganizationStatus(this.getOrganizationStatus());
       organization.setOrganizationType(this.getOrganizationType());
 
       result = organization;
@@ -85,6 +87,7 @@ public class OrganizationResult extends Organization {
     
     // Common fields in OrganizationBase
     result.setAlternativeNames(this.getAlternativeNames());
+    result.setCoverPhoto(this.getCoverPhoto());
     result.setCoverPhotoV2(this.getCoverPhotoV2());
     result.setDefaultLocale(this.getDefaultLocale());
     result.setDescription(this.getDescription());
@@ -98,8 +101,10 @@ public class OrganizationResult extends Organization {
     result.setVanityName(this.getVanityName());
     result.setVersionTag(this.getVersionTag());
     result.setWebsite(this.getWebsite());
+    result.setLogo(this.getLogo());
     result.setLogoV2(this.getLogoV2());
     result.setPrimaryOrganizationType(this.getPrimaryOrganizationType());
+    result.setUrn(this.getUrn());
     result.setId(this.getId());
     
     return result;

--- a/src/main/java/com/echobox/api/linkedin/types/organization/PrimaryOrganizationType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/PrimaryOrganizationType.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.organization;
+
+/**
+ * Primary orgranization type
+ * @see
+ * <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api?tabs=http">
+ * Organization Lookup</a>
+ *
+ * @author Kenneth Wong
+ *
+ */
+public enum PrimaryOrganizationType {
+  
+  /**
+   * Schools, such as Universities
+   */
+  SCHOOL,
+  
+  /**
+   * Organization brands (previously known as Showcase pages)
+   */
+  BRAND,
+  
+  /**
+   * Organizations
+   */
+  NONE
+}

--- a/src/test/java/com/echobox/api/linkedin/types/organization/OrganizationBrandTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/organization/OrganizationBrandTest.java
@@ -64,6 +64,7 @@ public class OrganizationBrandTest extends DefaultJsonMapperTestBase {
     
     assertEquals("urn:li:organization:2222222", 
         organizationBrand.getParentRelationship().getParent().toString());
+    assertEquals(PrimaryOrganizationType.BRAND, organizationBrand.getPrimaryOrganizationType());
   }
   
 }

--- a/src/test/java/com/echobox/api/linkedin/types/organization/OrganizationResultTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/organization/OrganizationResultTest.java
@@ -17,6 +17,9 @@
 
 package com.echobox.api.linkedin.types.organization;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapper;
 import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapperTestBase;
 import com.echobox.api.linkedin.types.objectype.MultiLocaleString;
@@ -26,22 +29,26 @@ import org.junit.Test;
 import java.util.List;
 
 /**
- * The type Organization test.
- * @author clementcaylux 
+ * Test for OrganizationResult to convert to Organization
+ * @author Kenneth Wong
  */
-public class OrganizationTest extends DefaultJsonMapperTestBase {
-
+public class OrganizationResultTest extends DefaultJsonMapperTestBase {
   /**
    * Test organization json can be deserialized.
    */
   @Test
   public void testOrganizationJsonCanBeDeserialized() {
-
+    
     String json = readFileToString("com.echobox.api.linkedin.jsonmapper/organization.json");
-
+    
     DefaultJsonMapper defaultJsonMapper = new DefaultJsonMapper();
     
-    Organization organization = defaultJsonMapper.toJavaObject(json, Organization.class);
+    OrganizationResult result = defaultJsonMapper.toJavaObject(json,
+        OrganizationResult.class);
+    OrganizationBase converted = result.getOrganization();
+    assertTrue(converted instanceof Organization);
+    
+    Organization organization = (Organization) converted;
     
     Assert.assertFalse(organization.getLocalizedDescription().isEmpty());
     Assert.assertEquals(1, organization.getLocations().size());
@@ -62,15 +69,15 @@ public class OrganizationTest extends DefaultJsonMapperTestBase {
     Assert.assertEquals(10, cropInfo.getYAxis());
     Assert.assertEquals(800, cropInfo.getWidth());
     Assert.assertEquals(800, cropInfo.getHeight());
-    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAH-AAAAJDRRlZTNlZDQwLTk4YTIt.png", 
+    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAH-AAAAJDRRlZTNlZDQwLTk4YTIt.png",
         logo.getOriginal().toString());
-    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAANyAAAAJGRlZTNlZDQwLTk4YTIt.png", 
+    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAANyAAAAJGRlZTNlZDQwLTk4YTIt.png",
         logo.getCropped().toString());
     
     Assert.assertEquals("linkedin", organization.getVanityName());
     
-    Assert.assertTrue(organization.getAlternativeNames().isEmpty());
-
+    assertTrue(organization.getAlternativeNames().isEmpty());
+    
     Assert.assertEquals(1337, organization.getId());
     
     Assert.assertEquals(1, organization.getIndustries().size());
@@ -81,36 +88,36 @@ public class OrganizationTest extends DefaultJsonMapperTestBase {
     Assert.assertEquals("LinkedIn", organization.getLocalizedName());
     
     Assert.assertEquals(new Integer(2003), organization.getFoundedOn().getYear());
-
+    
     Assert.assertEquals("http://www.linkedin.com", organization.getLocalizedWebsite());
-
+    
     MultiLocaleString website = organization.getWebsite();
     Assert.assertEquals("US", website.getPreferredLocale().getCountry());
     Assert.assertEquals("en", website.getPreferredLocale().getLanguage());
     Assert.assertEquals("http://www.linkedin.com", website.getLocalized().get("en_US"));
-
+    
     Assert.assertEquals("OPERATING", organization.getOrganizationStatus());
     
     MultiLocaleString description = organization.getDescription();
     Assert.assertEquals("US", description.getPreferredLocale().getCountry());
     Assert.assertEquals("en", description.getPreferredLocale().getLanguage());
-    Assert.assertTrue(description.getLocalized().containsKey("ja_JP"));
-    Assert.assertTrue(description.getLocalized().containsKey("en_US"));
-
+    assertTrue(description.getLocalized().containsKey("ja_JP"));
+    assertTrue(description.getLocalized().containsKey("en_US"));
+    
     Assert.assertEquals("PUBLIC_COMPANY", organization.getOrganizationType());
     
-    Assert.assertTrue(organization.getGroups().isEmpty());
+    assertTrue(organization.getGroups().isEmpty());
     
     Assert.assertEquals("US", organization.getDefaultLocale().getCountry());
     Assert.assertEquals("en", organization.getDefaultLocale().getLanguage());
-
+    
     Assert.assertEquals(8, organization.getLocalizedSpecialties().size());
-
+    
     MultiLocaleString name = organization.getName();
     Assert.assertEquals("US", name.getPreferredLocale().getCountry());
     Assert.assertEquals("en", name.getPreferredLocale().getLanguage());
     Assert.assertEquals(22, name.getLocalized().size());
-
+    
     Assert.assertEquals("SIZE_5001_TO_10000", organization.getStaffCountRange());
     
     List<Specialty> specialties = organization.getSpecialties();
@@ -119,18 +126,18 @@ public class OrganizationTest extends DefaultJsonMapperTestBase {
     Assert.assertEquals("US", specialty.getLocale().getCountry());
     Assert.assertEquals("en", specialty.getLocale().getLanguage());
     Assert.assertEquals(8, specialty.getTags().size());
-
+    
     CroppedImage coverPhoto = organization.getCoverPhoto();
     CropInfo cropInfoCoverPhoto = coverPhoto.getCropInfo();
     Assert.assertEquals(0, cropInfoCoverPhoto.getXAxis());
     Assert.assertEquals(0, cropInfoCoverPhoto.getYAxis());
     Assert.assertEquals(646, cropInfoCoverPhoto.getWidth());
     Assert.assertEquals(220, cropInfoCoverPhoto.getHeight());
-    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAfmAAAAJDQwLTk4YTItNGNlLWRj.png", 
+    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAfmAAAAJDQwLTk4YTItNGNlLWRj.png",
         coverPhoto.getOriginal().toString());
-    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAkOAAAAJDA3NmYwMzRkLTA2MTAt.png", 
+    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAkOAAAAJDA3NmYwMzRkLTA2MTAt.png",
         coverPhoto.getCropped().toString());
-  
+    
     CroppedImage overviewPhotoV2 = organization.getOverviewPhotoV2();
     CropInfo cropOverviewPhotoV2 = overviewPhotoV2.getCropInfo();
     Assert.assertEquals(0, cropOverviewPhotoV2.getXAxis());
@@ -141,7 +148,46 @@ public class OrganizationTest extends DefaultJsonMapperTestBase {
         overviewPhotoV2.getOriginal().toString());
     Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAkOAAAAJDA3NmYwMzRkLTA2MTAt.png",
         overviewPhotoV2.getCropped().toString());
-    Assert.assertEquals(PrimaryOrganizationType.NONE, organization.getPrimaryOrganizationType());
   }
-
+  
+  /**
+   * Test organization brand json can be deserialized.
+   */
+  @Test
+  public void testOrganizationBrandJsonCanBeDeserialized() {
+    String json = readFileToString(
+        "com.echobox.api.linkedin.jsonmapper/organizationBrand.json");
+    
+    DefaultJsonMapper defaultJsonMapper = new DefaultJsonMapper();
+    
+    OrganizationResult result = defaultJsonMapper.toJavaObject(json, OrganizationResult.class);
+    OrganizationBase converted = result.getOrganization();
+    assertTrue(converted instanceof OrganizationBrand);
+    OrganizationBrand organizationBrand = (OrganizationBrand) converted;
+    
+    assertEquals(11111111L, organizationBrand.getId());
+    assertEquals("example.com", organizationBrand.getLocalizedName());
+    
+    assertEquals("urn:li:media:/p/8/000/206/3de/1111111.png",
+        organizationBrand.getLogo().getCropped().toString());
+    assertEquals("urn:li:media:/p/8/000/206/3de/1111111.png",
+        organizationBrand.getLogo().getOriginal().toString());
+    assertEquals(0, organizationBrand.getLogo().getCropInfo().getHeight());
+    assertEquals(0, organizationBrand.getLogo().getCropInfo().getWidth());
+    assertEquals(0, organizationBrand.getLogo().getCropInfo().getXAxis());
+    assertEquals(0, organizationBrand.getLogo().getCropInfo().getYAxis());
+    
+    assertEquals("test_product", organizationBrand.getName().getLocalized().get("en_US"));
+    assertEquals("US", organizationBrand.getName().getPreferredLocale().getCountry());
+    assertEquals("en", organizationBrand.getName().getPreferredLocale().getLanguage());
+    
+    assertEquals("example.com", organizationBrand.getVanityName());
+    
+    assertEquals("2", organizationBrand.getVersionTag());
+    
+    assertEquals("urn:li:organization:2222222",
+        organizationBrand.getParentRelationship().getParent().toString());
+  }
+  
+  
 }

--- a/src/test/resources/com.echobox.api.linkedin.jsonmapper/organization.json
+++ b/src/test/resources/com.echobox.api.linkedin.jsonmapper/organization.json
@@ -140,5 +140,6 @@
     },
     "original": "urn:li:media:/AAEAAQAAAAAAAAfmAAAAJDQwLTk4YTItNGNlLWRj.png",
     "cropped": "urn:li:media:/AAEAAQAAAAAAAAkOAAAAJDA3NmYwMzRkLTA2MTAt.png"
-  }
+  },
+  "primaryOrganizationType": "NONE"
 }

--- a/src/test/resources/com.echobox.api.linkedin.jsonmapper/organizationBrand.json
+++ b/src/test/resources/com.echobox.api.linkedin.jsonmapper/organizationBrand.json
@@ -55,5 +55,6 @@
       "country": "US",
       "language": "en"
     }
-  }
+  },
+  "primaryOrganizationType": "BRAND"
 }


### PR DESCRIPTION
### Description of Changes

- Add primaryOrganizationType in OrganizationBase
- Update findOrganizationByVanityName 
  - return OrganizationBrand if primaryOrganizationType is BRAND
  - return Organization if primaryOrganizationType is NONE or SCHOOL

### Reference
https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api?tabs=http

### Documentation
N/A

### Risks & Impacts
- Add support for organization brands

### Testing
- Modified LinkedInMetaInfo to use new version
```
    OrganizationBase normal = LinkedInMetaInfo.getPageInfoByVanityName(linkedInAPI,
        "Echobox");
    System.out.println(organizationToString(normal));
  
    OrganizationBase showcase = LinkedInMetaInfo.getPageInfoByVanityName(linkedInAPI,
        "bio-basketball-brand");
    System.out.println(organizationToString(showcase));
  
    OrganizationBase school = LinkedInMetaInfo.getPageInfoByVanityName(linkedInAPI,
        "university-of-cambridge");
    System.out.println(organizationToString(school));
  
    OrganizationBase notFound = LinkedInMetaInfo.getPageInfoByVanityName(linkedInAPI,
        "news");
    System.out.println(organizationToString(notFound));
```
Print the type and data
```
  private static String organizationToString(OrganizationBase organization) {
    if (organization == null) {
      return "null";
    }
    StringBuilder sb = new StringBuilder();
    if (organization instanceof Organization) {
      Organization organization1 = (Organization) organization;
      sb.append("[Organization] - ");
      sb.append("vanityName: ").append(organization.getVanityName())
          .append(", primaryOrganizationType: ").append(organization.getPrimaryOrganizationType())
          .append(", locations: ").append(organization1.getLocations())
          .append(", organizationStatus: ").append(organization1.getOrganizationStatus())
          .append(", organizationType: ").append(organization1.getOrganizationType())
          .append(", deleted: ").append(organization1.getDeleted())
          .append(", entityStatus: ").append(organization1.getEntityStatus())
          .append(", groups: ").append(organization1.getGroups())
          .append(", localizedWebsite: ").append(organization1.getLocalizedWebsite())
          .append(", overviewPhotoV2: ").append(organization1.getOverviewPhotoV2())
          .append(", schoolAttributes: ").append(organization1.getSchoolAttributes())
          .append(", specialities: ").append(organization1.getSpecialties())
          .append(", staffCountRange: ").append(organization1.getStaffCountRange())
          .append(", alternativeNames: ").append(organization.getAlternativeNames())
          .append(", coverPhotoV2: ").append(organization.getCoverPhotoV2())
          .append(", defaultLocale: ").append(organization.getDefaultLocale())
          .append(", description: ").append(organization.getDescription())
          .append(", foundedOn: ").append(organization.getFoundedOn())
          .append(", id: ").append(organization.getId())
          .append(", industries: ").append(organization.getIndustries())
          .append(", localizedDescription: ").append(organization.getLocalizedDescription())
          .append(", localizedName: ").append(organization.getLocalizedName())
          .append(", logoV2: ").append(organization.getLogoV2())
          .append(", name: ").append(organization.getName())
          .append(", parentRelationship: ").append(organization.getParentRelationship())
          .append(", URN: ").append(organization.getUrn())
          .append(", versionTag: ").append(organization.getVersionTag())
          .append(", website: ").append(organization.getWebsite());
  
    } else if (organization instanceof OrganizationBrand) {
      OrganizationBrand organizationBrand = (OrganizationBrand) organization;
      sb.append("[OrganizationBrand] - ");
      sb.append("vanityName: ").append(organization.getVanityName())
          .append(", primaryOrganizationType: ").append(organization.getPrimaryOrganizationType())
          .append(", alternativeNames: ").append(organization.getAlternativeNames())
          .append(", coverPhotoV2: ").append(organization.getCoverPhotoV2())
          .append(", defaultLocale: ").append(organization.getDefaultLocale())
          .append(", description: ").append(organization.getDescription())
          .append(", foundedOn: ").append(organization.getFoundedOn())
          .append(", id: ").append(organization.getId())
          .append(", industries: ").append(organization.getIndustries())
          .append(", localizedDescription: ").append(organization.getLocalizedDescription())
          .append(", localizedName: ").append(organization.getLocalizedName())
          .append(", logoV2: ").append(organization.getLogoV2())
          .append(", name: ").append(organization.getName())
          .append(", parentRelationship: ").append(organization.getParentRelationship())
          .append(", URN: ").append(organization.getUrn())
          .append(", versionTag: ").append(organization.getVersionTag())
          .append(", website: ").append(organization.getWebsite())
          .append(", tags: ").append(organizationBrand.getTags())
          .append(", pinnedPost: ").append(organizationBrand.getPinnedPost())
          .append(", autoCreated: ").append(organizationBrand.getAutoCreated());
    }
    return sb.toString();
  }
```
Result:
```
[Organization] - vanityName: echobox, primaryOrganizationType: NONE, locations: [com.echobox.api.linkedin.types.organization.LocationInfo@6869a3b3, com.echobox.api.linkedin.types.organization.LocationInfo@6ab4ba9f, com.echobox.api.linkedin.types.organization.LocationInfo@27ace0b1], organizationStatus: null, organizationType: null, deleted: null, entityStatus: null, groups: null, localizedWebsite: https://www.echobox.com, overviewPhotoV2: null, schoolAttributes: null, specialities: null, staffCountRange: null, alternativeNames: null, coverPhotoV2: null, defaultLocale: null, description: null, foundedOn: null, id: 5268030, industries: null, localizedDescription: null, localizedName: Echobox, logoV2: com.echobox.api.linkedin.types.organization.CroppedImage@664e5dee, name: com.echobox.api.linkedin.types.objectype.MultiLocaleString@431f1eaf, parentRelationship: null, URN: null, versionTag: null, website: null
[OrganizationBrand] - vanityName: bio-basketball-brand, primaryOrganizationType: BRAND, alternativeNames: null, coverPhotoV2: null, defaultLocale: null, description: null, foundedOn: null, id: 80927451, industries: null, localizedDescription: null, localizedName: bio basketball brand, logoV2: com.echobox.api.linkedin.types.organization.CroppedImage@46cb98a3, name: com.echobox.api.linkedin.types.objectype.MultiLocaleString@3ffb3598, parentRelationship: null, URN: null, versionTag: null, website: null, tags: null, pinnedPost: null, autoCreated: null
[Organization] - vanityName: university-of-cambridge, primaryOrganizationType: SCHOOL, locations: [com.echobox.api.linkedin.types.organization.LocationInfo@4a34e9f], organizationStatus: null, organizationType: null, deleted: null, entityStatus: null, groups: null, localizedWebsite: https://www.cam.ac.uk/, overviewPhotoV2: null, schoolAttributes: com.echobox.api.linkedin.types.organization.SchoolAttribute@6f6621e3, specialities: null, staffCountRange: null, alternativeNames: null, coverPhotoV2: null, defaultLocale: null, description: null, foundedOn: null, id: 4522, industries: null, localizedDescription: null, localizedName: University of Cambridge, logoV2: com.echobox.api.linkedin.types.organization.CroppedImage@3fc05ea2, name: com.echobox.api.linkedin.types.objectype.MultiLocaleString@7c891ba7, parentRelationship: null, URN: null, versionTag: null, website: null
null

```

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.