### PR TITLE
Release 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,4 +93,6 @@ sorted by creation date.
 ## 2.0.1 (Jan 13, 2020)
 * Change `RegisterUploadRequestBody.supportedUploadMechanism` from `SupportedUploadMechanism ` to `List< SupportedUploadMechanism >`
 
-## 2.0.1 (Work in Progress)
+## 3.0.0 (October 19, 2021)
+* Change `OrganizationConnection.fetchMemberOrganizationAccessControl` and `OrganizationConnection.findOrganizationAccessControl`
+to use `/OrganizationAcls` endpoint instead of `/OrganizationalEntityAcls` endpoint as the LinkedIn API will remove support for organisation entity ACLs  and replace it with organisation ACLs on October 30, 2021.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,6 @@ sorted by creation date.
 ## 3.0.0 (October 19, 2021)
 * Change `OrganizationConnection.fetchMemberOrganizationAccessControl` and `OrganizationConnection.findOrganizationAccessControl`
 to use `/OrganizationAcls` endpoint instead of `/OrganizationalEntityAcls` endpoint as the LinkedIn API will remove support for organisation entity ACLs  and replace it with organisation ACLs on October 30, 2021.
+
+## 3.0.1 (Work in progress)
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,4 +106,9 @@ can get data for both organization and organization brand pages.
   security vulnerability. See [CVE-2017-5929](https://nvd.nist.gov/vuln/detail/CVE-2017-5929) 
   for more information. Using ebx-structured-logging instead.
 
-## 3.0.3 (Work in progress)
+## 3.0.3 (Mar 25, 2022)
+* Add attribute `primaryOrganizationType` in OrganizationBase class
+* Update `findOrganizationByVanityName` to return `OrganizationBrand` if `primaryOrganizationType` is 
+  `BRAND`.
+
+## 3.0.4 (Work in progress)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,4 +101,9 @@ to use `/OrganizationAcls` endpoint instead of `/OrganizationalEntityAcls` endpo
 * Ensure `OrganizationConnection.retrieveOrganizationFollowerCount` and `OrgnizationConnection. retrieveShareStatistics`
 can get data for both organization and organization brand pages.
 
-## 3.0.2 (Work in progress)
+## 3.0.2 (Dec 20, 2021)
+* Update logback dependencies to move away from logback-classic and logback-core due to a 
+  security vulnerability. See [CVE-2017-5929](https://nvd.nist.gov/vuln/detail/CVE-2017-5929) 
+  for more information. Using ebx-structured-logging instead.
+
+## 3.0.3 (Work in progress)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,5 +97,7 @@ sorted by creation date.
 * Change `OrganizationConnection.fetchMemberOrganizationAccessControl` and `OrganizationConnection.findOrganizationAccessControl`
 to use `/OrganizationAcls` endpoint instead of `/OrganizationalEntityAcls` endpoint as the LinkedIn API will remove support for organisation entity ACLs  and replace it with organisation ACLs on October 30, 2021.
 
-## 3.0.1 (Work in progress)
+## 3.0.1 (Dec 2, 2021)
+* Ensure `OrganizationConnection.retrieveOrganizationFollowerCount` and `OrgnizationConnection. retrieveShareStatistics`
+can get data for both organization and organization brand pages.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,3 +101,4 @@ to use `/OrganizationAcls` endpoint instead of `/OrganizationalEntityAcls` endpo
 * Ensure `OrganizationConnection.retrieveOrganizationFollowerCount` and `OrgnizationConnection. retrieveShareStatistics`
 can get data for both organization and organization brand pages.
 
+## 3.0.2 (Work in progress)

--- a/CodeStyle/checkstyle.xml
+++ b/CodeStyle/checkstyle.xml
@@ -225,7 +225,7 @@
         <module name="SuperClone"/>
         <!--JavaDoc-->
         <module name="JavadocMethod">
-            <property name="scope" value="package"/>
+            <property name="accessModifiers" value="package, protected, public"/>
             <property name="allowedAnnotations" value="Override, Test, Mock, Before"/>
         </module>
         <module name="JavadocVariable">

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ use:
 ```
 
 ## Installation (Most Up To Date)
-[![Build Status](https://travis-ci.org/ebx/ebx-linkedin-sdk.svg?branch=dev)](https://travis-ci.org/ebx/ebx-linkedin-sdk)
+[![Build Status](https://travis-ci.org/ebx/ebx-linkedin-sdk.svg?branch=dev)](https://app.travis-ci.com/github/ebx/ebx-linkedin-sdk)
 
 If you'd like to use the latest SNAPSHOT build please ensure you have snapshots enabled in your pom:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>3.0.2</version>
+  <version>3.0.3</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>3.0.1</version>
+  <version>3.0.2</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>2.0.1</version>
+  <version>3.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.37</version>
+            <version>8.45</version>
           </dependency>
           <dependency>
             <groupId>com.github.sevntu-checkstyle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>3.0.2</version>
+  <version>3.0.3</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -78,15 +78,9 @@
       <version>1.7.30</version>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback.contrib</groupId>
-      <artifactId>logback-json-classic</artifactId>
-      <version>0.1.5</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback.contrib</groupId>
-      <artifactId>logback-jackson</artifactId>
-      <version>0.1.5</version>
+      <groupId>com.echobox</groupId>
+      <artifactId>ebx-structuredlogging-sdk</artifactId>
+      <version>1.0.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>2.0.2</version>
+  <version>3.0.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>3.0.1</version>
+  <version>3.0.2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
@@ -24,7 +24,9 @@ import com.echobox.api.linkedin.types.engagement.ShareStatistic;
 import com.echobox.api.linkedin.types.organization.AccessControl;
 import com.echobox.api.linkedin.types.organization.NetworkSize;
 import com.echobox.api.linkedin.types.organization.Organization;
+import com.echobox.api.linkedin.types.organization.OrganizationBase;
 import com.echobox.api.linkedin.types.organization.OrganizationBrand;
+import com.echobox.api.linkedin.types.organization.OrganizationResult;
 import com.echobox.api.linkedin.types.statistics.OrganizationFollowerStatistics;
 import com.echobox.api.linkedin.types.statistics.page.FollowerStatistic;
 import com.echobox.api.linkedin.types.statistics.page.Statistics;
@@ -35,6 +37,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Organization connection class that should contain all organization operations
@@ -156,8 +159,8 @@ public class OrganizationConnection extends ConnectionBaseV2 {
    * @param count the number of entries to be returned per paged request
    * @return The organization with the vanity name
    */
-  public List<Organization> findOrganizationByVanityName(String vanityName, Parameter fields,
-      Integer count) {
+  public List<OrganizationBase> findOrganizationByVanityName(String vanityName,
+      Parameter fields, Integer count) {
     ValidationUtils.verifyParameterPresence("vanityName", vanityName);
   
     List<Parameter> parameters = new ArrayList<>();
@@ -167,8 +170,11 @@ public class OrganizationConnection extends ConnectionBaseV2 {
     parameters.add(Parameter.with(QUERY_KEY, VANITY_NAME_VALUE));
     parameters.add(Parameter.with(VANITY_NAME_KEY, vanityName));
     addStartAndCountParams(parameters, null, count);
-    return getListFromQuery(ORGANIZATIONS, Organization.class,
-        parameters.toArray(new Parameter[0]));
+    List<OrganizationResult> organizationList = getListFromQuery(ORGANIZATIONS,
+        OrganizationResult.class, parameters.toArray(new Parameter[0]));
+    
+    return organizationList.stream().map(OrganizationResult::getOrganization)
+        .collect(Collectors.toList());
   }
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
@@ -203,7 +203,7 @@ public class OrganizationConnection extends ConnectionBaseV2 {
    * @return the number of followers for the organization
    */
   public Long retrieveOrganizationFollowerCount(URN organizationURN) {
-    validateOrganizationURN("organizationURN", organizationURN);
+    validateOrganizationOrBrandURN("organizationURN", organizationURN);
     NetworkSize networkSize = linkedinClient.fetchObject(NETWORK_SIZES + "/" + organizationURN,
         NetworkSize.class, Parameter.with(EDGE_TYPE, COMPANY_FOLLOWED_BY_MEMEBER));
     return networkSize.getFirstDegreeSize();
@@ -395,7 +395,7 @@ public class OrganizationConnection extends ConnectionBaseV2 {
    */
   public List<ShareStatistic> retrieveShareStatistics(URN organizationURN,
       TimeInterval timeInterval, List<URN> shareURNs, Integer count) {
-    validateOrganizationURN("organizationURN", organizationURN);
+    validateOrganizationOrBrandURN("organizationURN", organizationURN);
     
     List<Parameter> params = new ArrayList<>();
     params.add(Parameter.with(QUERY_KEY, ORGANIZATIONAL_ENTITY_KEY));
@@ -411,6 +411,15 @@ public class OrganizationConnection extends ConnectionBaseV2 {
     
     return getListFromQuery(SHARE_STATISTICS, ShareStatistic.class,
         params.toArray(new Parameter[0]));
+  }
+  
+  private void validateOrganizationOrBrandURN(String paramName, URN organizationOrBrandURN) {
+    ValidationUtils.verifyParameterPresence(paramName, organizationOrBrandURN);
+    if (!(URNEntityType.ORGANIZATION.equals(organizationOrBrandURN.resolveURNEntityType())
+        || URNEntityType.ORGANIZATIONBRAND.equals(organizationOrBrandURN.resolveURNEntityType()))) {
+      throw new IllegalArgumentException(String.format("The URN should be type %s or %s",
+          URNEntityType.ORGANIZATION, URNEntityType.ORGANIZATIONBRAND));
+    }
   }
 
   private void validateOrganizationURN(String paramName, URN organizationURN) {

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
@@ -46,8 +46,8 @@ import java.util.List;
  *
  */
 public class OrganizationConnection extends ConnectionBaseV2 {
-
-  private static final String ORGANIZATIONAL_ENTITY_ACLS = "/organizationalEntityAcls";
+  
+  private static final String ORGANIZATION_ACLS = "/organizationAcls";
   private static final String ORGANIZATIONS = "/organizations";
   private static final String ORGANIZATIONS_BRANDS = "/organizationBrands";
   private static final String ORGANIZATIONAL_ENTITY_FOLOWER_STATS =
@@ -58,14 +58,12 @@ public class OrganizationConnection extends ConnectionBaseV2 {
   
   private static final String ROLE_KEY = "role";
   private static final String STATE_KEY = "state";
-  private static final String ORGANIZATIONAL_TARGET_KEY = "organizationalTarget";
   private static final String VANITY_NAME_KEY = "vanityName";
   private static final String EMAIL_DOMAIN_KEY = "emailDomain";
   private static final String ORGANIZATIONAL_ENTITY_KEY = "organizationalEntity";
   private static final String ORGANIZATION_KEY = "organization";
   
   private static final String ROLE_ASSIGNEE_VALUE = "roleAssignee";
-  private static final String ORGANIZATION_TARGET_VALUE = "organizationalTarget";
   private static final String VANITY_NAME_VALUE = "vanityName";
   private static final String EMAIL_DOMAIN_VALUE = "emailDomain";
   private static final String ORGANIZATIONAL_ENTITY_VALUE = "organizationalEntity";
@@ -85,8 +83,8 @@ public class OrganizationConnection extends ConnectionBaseV2 {
 
   /**
    * Find a Member's Organization Access Control Information
-   * E.g. https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee
-   * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-access-control">
+   * E.g. https://api.linkedin.com/v2/organizationAcls?q=roleAssignee
+   * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-access-control-by-role">
    * Access Control</a>
    * @param role Limit results to specific roles, such as ADMINISTRATOR.
    * @param state Limit results to specific role states, such as APPROVED.
@@ -96,20 +94,20 @@ public class OrganizationConnection extends ConnectionBaseV2 {
    */
   public List<AccessControl> fetchMemberOrganizationAccessControl(String role, String state,
       Parameter projection, Integer count) {
-    List<Parameter> parameters = new ArrayList<>();
-    parameters.add(Parameter.with(QUERY_KEY, ROLE_ASSIGNEE_VALUE));
-    addRoleStateParams(role, state, projection, parameters);
-    addStartAndCountParams(parameters, null, count);
-
-    return getListFromQuery(ORGANIZATIONAL_ENTITY_ACLS, AccessControl.class,
-        parameters.toArray(new Parameter[0]));
+    List<Parameter> params = new ArrayList<>();
+    params.add(Parameter.with(QUERY_KEY, ROLE_ASSIGNEE_VALUE));
+    addRoleStateParams(role, state, projection, params);
+    addStartAndCountParams(params, null, count);
+    
+    return getListFromQuery(ORGANIZATION_ACLS, AccessControl.class,
+        params.toArray(new Parameter[0]));
   }
-
+  
   /**
    * Find an Organization's Access Control Information
-   * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-access-control">
+   * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-access-control-by-role">
    * Access Control</a>
-   * @param organizationalTarget The organizational entity for which access control information
+   * @param organizationURN The organization for which access control information
    * is retrieved.
    * @param role Limit results to specific roles
    * @param state Limit results to specific role states
@@ -117,17 +115,18 @@ public class OrganizationConnection extends ConnectionBaseV2 {
    * @param count the number of entries to be returned per paged request
    * @return List of access controls for an organization
    */
-  public List<AccessControl> findOrganizationAccessControl(URN organizationalTarget, String role,
+  public List<AccessControl> findOrganizationAccessControl(URN organizationURN,
+      String role,
       String state, Parameter projection, Integer count) {
-    validateOrganizationURN("organizationalTarget", organizationalTarget);
-
+    validateOrganizationURN("organization", organizationURN);
+    
     List<Parameter> parameters = new ArrayList<>();
-    parameters.add(Parameter.with(QUERY_KEY, ORGANIZATION_TARGET_VALUE));
-    parameters.add(Parameter.with(ORGANIZATIONAL_TARGET_KEY, organizationalTarget.toString()));
+    parameters.add(Parameter.with(QUERY_KEY, ORGANIZATION_VALUE));
+    parameters.add(Parameter.with(ORGANIZATION_KEY, organizationURN.toString()));
     addRoleStateParams(role, state, projection, parameters);
     addStartAndCountParams(parameters, null, count);
-
-    return getListFromQuery(ORGANIZATIONAL_ENTITY_ACLS, AccessControl.class,
+    
+    return getListFromQuery(ORGANIZATION_ACLS, AccessControl.class,
         parameters.toArray(new Parameter[0]));
   }
 

--- a/src/main/java/com/echobox/api/linkedin/types/organization/AccessControl.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/AccessControl.java
@@ -23,7 +23,7 @@ import lombok.Getter;
 
 /**
  * Access Control POJO
- * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-access-control#find-access-control-information">
+ * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-access-control-by-role">
  * Access Control Schema</a>
  * @author joanna
  *
@@ -47,12 +47,12 @@ public class AccessControl {
   private RoleAssignee roleAssignee;
   
   @Getter
-  @LinkedIn("organizationalTarget")
-  private URN organizationalTargetURN;
+  @LinkedIn("organization")
+  private URN organizationURN;
   
   @Getter
-  @LinkedIn("organizationalTarget~")
-  private OrganizationalTarget organizationalTarget;
+  @LinkedIn("organization~")
+  private Organization organization;
   
   /**
    * Role Assignee
@@ -66,16 +66,6 @@ public class AccessControl {
     @Getter
     @LinkedIn
     private String localizedFirstName;
-  }
-  
-  /**
-   * Organization target
-   * @author Joanna
-   */
-  public static class OrganizationalTarget {
-    @Getter
-    @LinkedIn
-    private String localizedName;
   }
   
 }

--- a/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationBase.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationBase.java
@@ -180,4 +180,12 @@ public abstract class OrganizationBase extends LinkedInIdAndURNType {
   @LinkedIn
   private CroppedImage logoV2;
   
+  /**
+   * Primary Organization type
+   */
+  @Getter
+  @Setter
+  @LinkedIn
+  private PrimaryOrganizationType primaryOrganizationType;
+  
 }

--- a/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationResult.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationResult.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.organization;
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Class for deserialising from Organization endpoint, which may return Organization or
+ * OrganizationBrand
+ * This class should contain all fields from Organization and OrganizationBrand
+ * @author Kenneth Wong
+ */
+public class OrganizationResult extends Organization {
+  
+  /**
+   * Admin-defined specialty tags of the entity.
+   */
+  @Getter
+  @Setter
+  @LinkedIn
+  private List<Specialty> tags;
+  
+  /**
+   * The URN of the entity's pinned post.
+   */
+  @Getter
+  @Setter
+  @LinkedIn
+  private String pinnedPost;
+  
+  
+  /**
+   * Whether the entity was auto-created.
+   */
+  @Getter
+  @Setter
+  @LinkedIn
+  private Boolean autoCreated;
+  
+  public OrganizationBase getOrganization() {
+    OrganizationBase result;
+    if (PrimaryOrganizationType.BRAND.equals(this.getPrimaryOrganizationType())) {
+      // OrganizationBrand
+      OrganizationBrand brand = new OrganizationBrand();
+      brand.setTags(this.getTags());
+      brand.setPinnedPost(this.getPinnedPost());
+      brand.setAutoCreated(this.getAutoCreated());
+      
+      result = brand;
+    } else {
+      // Organization
+      Organization organization = new Organization();
+      organization.setDeleted(this.getDeleted());
+      organization.setEntityStatus(this.getEntityStatus());
+      organization.setGroups(this.getGroups());
+      organization.setLocalizedWebsite(this.getLocalizedWebsite());
+      organization.setLocations(this.getLocations());
+      organization.setSpecialties(this.getSpecialties());
+      organization.setStaffCountRange(this.getStaffCountRange());
+      organization.setSchoolAttributes(this.getSchoolAttributes());
+      organization.setOverviewPhoto(this.getOverviewPhoto());
+      organization.setOverviewPhotoV2(this.getOverviewPhotoV2());
+      organization.setOrganizationStatus(this.getOrganizationStatus());
+      organization.setOrganizationType(this.getOrganizationType());
+
+      result = organization;
+    }
+    
+    // Common fields in OrganizationBase
+    result.setAlternativeNames(this.getAlternativeNames());
+    result.setCoverPhoto(this.getCoverPhoto());
+    result.setCoverPhotoV2(this.getCoverPhotoV2());
+    result.setDefaultLocale(this.getDefaultLocale());
+    result.setDescription(this.getDescription());
+    result.setFoundedOn(this.getFoundedOn());
+    result.setLocalizedDescription(this.getLocalizedDescription());
+    result.setIndustries(this.getIndustries());
+    result.setLocalizedName(this.getLocalizedName());
+    result.setLocalizedSpecialties(this.getLocalizedSpecialties());
+    result.setName(this.getName());
+    result.setParentRelationship(this.getParentRelationship());
+    result.setVanityName(this.getVanityName());
+    result.setVersionTag(this.getVersionTag());
+    result.setWebsite(this.getWebsite());
+    result.setLogo(this.getLogo());
+    result.setLogoV2(this.getLogoV2());
+    result.setPrimaryOrganizationType(this.getPrimaryOrganizationType());
+    result.setUrn(this.getUrn());
+    result.setId(this.getId());
+    
+    return result;
+  }
+}

--- a/src/main/java/com/echobox/api/linkedin/types/organization/PrimaryOrganizationType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/PrimaryOrganizationType.java
@@ -15,23 +15,31 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.types;
-
-import com.echobox.api.linkedin.jsonmapper.LinkedIn;
-import com.echobox.api.linkedin.types.urn.URN;
-import lombok.Getter;
-import lombok.Setter;
+package com.echobox.api.linkedin.types.organization;
 
 /**
- * Linked in types that contain a URN field
- * @author Joanna
+ * Primary orgranization type
+ * @see
+ * <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api?tabs=http">
+ * Organization Lookup</a>
+ *
+ * @author Kenneth Wong
  *
  */
-public abstract class LinkedInIdAndURNType extends LinkedInIdType {
+public enum PrimaryOrganizationType {
   
-  @Getter
-  @Setter
-  @LinkedIn("$URN")
-  private URN urn;
-
+  /**
+   * Schools, such as Universities
+   */
+  SCHOOL,
+  
+  /**
+   * Organization brands (previously known as Showcase pages)
+   */
+  BRAND,
+  
+  /**
+   * Organizations
+   */
+  NONE
 }

--- a/src/test/java/com/echobox/api/linkedin/types/organization/OrganizationBrandTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/organization/OrganizationBrandTest.java
@@ -64,6 +64,7 @@ public class OrganizationBrandTest extends DefaultJsonMapperTestBase {
     
     assertEquals("urn:li:organization:2222222", 
         organizationBrand.getParentRelationship().getParent().toString());
+    assertEquals(PrimaryOrganizationType.BRAND, organizationBrand.getPrimaryOrganizationType());
   }
   
 }

--- a/src/test/java/com/echobox/api/linkedin/types/organization/OrganizationResultTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/organization/OrganizationResultTest.java
@@ -17,6 +17,9 @@
 
 package com.echobox.api.linkedin.types.organization;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapper;
 import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapperTestBase;
 import com.echobox.api.linkedin.types.objectype.MultiLocaleString;
@@ -26,22 +29,26 @@ import org.junit.Test;
 import java.util.List;
 
 /**
- * The type Organization test.
- * @author clementcaylux 
+ * Test for OrganizationResult to convert to Organization
+ * @author Kenneth Wong
  */
-public class OrganizationTest extends DefaultJsonMapperTestBase {
-
+public class OrganizationResultTest extends DefaultJsonMapperTestBase {
   /**
    * Test organization json can be deserialized.
    */
   @Test
   public void testOrganizationJsonCanBeDeserialized() {
-
+    
     String json = readFileToString("com.echobox.api.linkedin.jsonmapper/organization.json");
-
+    
     DefaultJsonMapper defaultJsonMapper = new DefaultJsonMapper();
     
-    Organization organization = defaultJsonMapper.toJavaObject(json, Organization.class);
+    OrganizationResult result = defaultJsonMapper.toJavaObject(json,
+        OrganizationResult.class);
+    OrganizationBase converted = result.getOrganization();
+    assertTrue(converted instanceof Organization);
+    
+    Organization organization = (Organization) converted;
     
     Assert.assertFalse(organization.getLocalizedDescription().isEmpty());
     Assert.assertEquals(1, organization.getLocations().size());
@@ -62,15 +69,15 @@ public class OrganizationTest extends DefaultJsonMapperTestBase {
     Assert.assertEquals(10, cropInfo.getYAxis());
     Assert.assertEquals(800, cropInfo.getWidth());
     Assert.assertEquals(800, cropInfo.getHeight());
-    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAH-AAAAJDRRlZTNlZDQwLTk4YTIt.png", 
+    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAH-AAAAJDRRlZTNlZDQwLTk4YTIt.png",
         logo.getOriginal().toString());
-    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAANyAAAAJGRlZTNlZDQwLTk4YTIt.png", 
+    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAANyAAAAJGRlZTNlZDQwLTk4YTIt.png",
         logo.getCropped().toString());
     
     Assert.assertEquals("linkedin", organization.getVanityName());
     
-    Assert.assertTrue(organization.getAlternativeNames().isEmpty());
-
+    assertTrue(organization.getAlternativeNames().isEmpty());
+    
     Assert.assertEquals(1337, organization.getId());
     
     Assert.assertEquals(1, organization.getIndustries().size());
@@ -81,36 +88,36 @@ public class OrganizationTest extends DefaultJsonMapperTestBase {
     Assert.assertEquals("LinkedIn", organization.getLocalizedName());
     
     Assert.assertEquals(new Integer(2003), organization.getFoundedOn().getYear());
-
+    
     Assert.assertEquals("http://www.linkedin.com", organization.getLocalizedWebsite());
-
+    
     MultiLocaleString website = organization.getWebsite();
     Assert.assertEquals("US", website.getPreferredLocale().getCountry());
     Assert.assertEquals("en", website.getPreferredLocale().getLanguage());
     Assert.assertEquals("http://www.linkedin.com", website.getLocalized().get("en_US"));
-
+    
     Assert.assertEquals("OPERATING", organization.getOrganizationStatus());
     
     MultiLocaleString description = organization.getDescription();
     Assert.assertEquals("US", description.getPreferredLocale().getCountry());
     Assert.assertEquals("en", description.getPreferredLocale().getLanguage());
-    Assert.assertTrue(description.getLocalized().containsKey("ja_JP"));
-    Assert.assertTrue(description.getLocalized().containsKey("en_US"));
-
+    assertTrue(description.getLocalized().containsKey("ja_JP"));
+    assertTrue(description.getLocalized().containsKey("en_US"));
+    
     Assert.assertEquals("PUBLIC_COMPANY", organization.getOrganizationType());
     
-    Assert.assertTrue(organization.getGroups().isEmpty());
+    assertTrue(organization.getGroups().isEmpty());
     
     Assert.assertEquals("US", organization.getDefaultLocale().getCountry());
     Assert.assertEquals("en", organization.getDefaultLocale().getLanguage());
-
+    
     Assert.assertEquals(8, organization.getLocalizedSpecialties().size());
-
+    
     MultiLocaleString name = organization.getName();
     Assert.assertEquals("US", name.getPreferredLocale().getCountry());
     Assert.assertEquals("en", name.getPreferredLocale().getLanguage());
     Assert.assertEquals(22, name.getLocalized().size());
-
+    
     Assert.assertEquals("SIZE_5001_TO_10000", organization.getStaffCountRange());
     
     List<Specialty> specialties = organization.getSpecialties();
@@ -119,18 +126,18 @@ public class OrganizationTest extends DefaultJsonMapperTestBase {
     Assert.assertEquals("US", specialty.getLocale().getCountry());
     Assert.assertEquals("en", specialty.getLocale().getLanguage());
     Assert.assertEquals(8, specialty.getTags().size());
-
+    
     CroppedImage coverPhoto = organization.getCoverPhoto();
     CropInfo cropInfoCoverPhoto = coverPhoto.getCropInfo();
     Assert.assertEquals(0, cropInfoCoverPhoto.getXAxis());
     Assert.assertEquals(0, cropInfoCoverPhoto.getYAxis());
     Assert.assertEquals(646, cropInfoCoverPhoto.getWidth());
     Assert.assertEquals(220, cropInfoCoverPhoto.getHeight());
-    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAfmAAAAJDQwLTk4YTItNGNlLWRj.png", 
+    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAfmAAAAJDQwLTk4YTItNGNlLWRj.png",
         coverPhoto.getOriginal().toString());
-    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAkOAAAAJDA3NmYwMzRkLTA2MTAt.png", 
+    Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAkOAAAAJDA3NmYwMzRkLTA2MTAt.png",
         coverPhoto.getCropped().toString());
-  
+    
     CroppedImage overviewPhotoV2 = organization.getOverviewPhotoV2();
     CropInfo cropOverviewPhotoV2 = overviewPhotoV2.getCropInfo();
     Assert.assertEquals(0, cropOverviewPhotoV2.getXAxis());
@@ -141,7 +148,46 @@ public class OrganizationTest extends DefaultJsonMapperTestBase {
         overviewPhotoV2.getOriginal().toString());
     Assert.assertEquals("urn:li:media:/AAEAAQAAAAAAAAkOAAAAJDA3NmYwMzRkLTA2MTAt.png",
         overviewPhotoV2.getCropped().toString());
-    Assert.assertEquals(PrimaryOrganizationType.NONE, organization.getPrimaryOrganizationType());
   }
-
+  
+  /**
+   * Test organization brand json can be deserialized.
+   */
+  @Test
+  public void testOrganizationBrandJsonCanBeDeserialized() {
+    String json = readFileToString(
+        "com.echobox.api.linkedin.jsonmapper/organizationBrand.json");
+    
+    DefaultJsonMapper defaultJsonMapper = new DefaultJsonMapper();
+    
+    OrganizationResult result = defaultJsonMapper.toJavaObject(json, OrganizationResult.class);
+    OrganizationBase converted = result.getOrganization();
+    assertTrue(converted instanceof OrganizationBrand);
+    OrganizationBrand organizationBrand = (OrganizationBrand) converted;
+    
+    assertEquals(11111111L, organizationBrand.getId());
+    assertEquals("example.com", organizationBrand.getLocalizedName());
+    
+    assertEquals("urn:li:media:/p/8/000/206/3de/1111111.png",
+        organizationBrand.getLogo().getCropped().toString());
+    assertEquals("urn:li:media:/p/8/000/206/3de/1111111.png",
+        organizationBrand.getLogo().getOriginal().toString());
+    assertEquals(0, organizationBrand.getLogo().getCropInfo().getHeight());
+    assertEquals(0, organizationBrand.getLogo().getCropInfo().getWidth());
+    assertEquals(0, organizationBrand.getLogo().getCropInfo().getXAxis());
+    assertEquals(0, organizationBrand.getLogo().getCropInfo().getYAxis());
+    
+    assertEquals("test_product", organizationBrand.getName().getLocalized().get("en_US"));
+    assertEquals("US", organizationBrand.getName().getPreferredLocale().getCountry());
+    assertEquals("en", organizationBrand.getName().getPreferredLocale().getLanguage());
+    
+    assertEquals("example.com", organizationBrand.getVanityName());
+    
+    assertEquals("2", organizationBrand.getVersionTag());
+    
+    assertEquals("urn:li:organization:2222222",
+        organizationBrand.getParentRelationship().getParent().toString());
+  }
+  
+  
 }

--- a/src/test/resources/com.echobox.api.linkedin.jsonmapper/organization.json
+++ b/src/test/resources/com.echobox.api.linkedin.jsonmapper/organization.json
@@ -140,5 +140,6 @@
     },
     "original": "urn:li:media:/AAEAAQAAAAAAAAfmAAAAJDQwLTk4YTItNGNlLWRj.png",
     "cropped": "urn:li:media:/AAEAAQAAAAAAAAkOAAAAJDA3NmYwMzRkLTA2MTAt.png"
-  }
+  },
+  "primaryOrganizationType": "NONE"
 }

--- a/src/test/resources/com.echobox.api.linkedin.jsonmapper/organizationBrand.json
+++ b/src/test/resources/com.echobox.api.linkedin.jsonmapper/organizationBrand.json
@@ -55,5 +55,6 @@
       "country": "US",
       "language": "en"
     }
-  }
+  },
+  "primaryOrganizationType": "BRAND"
 }


### PR DESCRIPTION
### Description of Changes
Release 3.0.3

- Add primaryOrganizationType in OrganizationBase
- Update findOrganizationByVanityName 
  - return OrganizationBrand if primaryOrganizationType is BRAND
  - otherwise return Organization

### Documentation
- https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api?tabs=http

### Risks & Impacts
- Release 3.0.3

### Testing
- N/A

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.