### PR TITLE
TEC-16993 Update LinkedInSDK to Handle Json Numbers Correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,5 +111,5 @@ can get data for both organization and organization brand pages.
 * Update `findOrganizationByVanityName` to return `OrganizationBrand` if `primaryOrganizationType` is 
   `BRAND`.
 
-## 3.0.4 (Work in progress)
+## 3.0.4 (Apr 1, 2022)
 * Update `JsonUtils.getValue` method to handle JsonNumeric values correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,3 +112,4 @@ can get data for both organization and organization brand pages.
   `BRAND`.
 
 ## 3.0.4 (Work in progress)
+* Update `JsonUtils.getValue` method to handle JsonNumeric values correctly.

--- a/src/main/java/com/echobox/api/linkedin/util/JsonUtils.java
+++ b/src/main/java/com/echobox/api/linkedin/util/JsonUtils.java
@@ -65,8 +65,22 @@ public abstract class JsonUtils {
       value = toMap(jsonValue.asObject());
     } else if (jsonValue.isString()) {
       value = jsonValue.asString();
+    } else if (jsonValue.isNumber()) {
+      value = getNumber(jsonValue);
     }
     return value;
+  }
+  
+  private static Object getNumber(JsonValue jsonValue) {
+    try {
+      return jsonValue.asLong();
+    } catch (NumberFormatException e) {
+      try {
+        return jsonValue.asDouble();
+      } catch (NumberFormatException ex) {
+        return jsonValue;
+      }
+    }
   }
 
 }

--- a/src/main/java/com/echobox/api/linkedin/util/JsonUtils.java
+++ b/src/main/java/com/echobox/api/linkedin/util/JsonUtils.java
@@ -72,6 +72,9 @@ public abstract class JsonUtils {
   }
   
   private static Object getNumber(JsonValue jsonValue) {
+    if (!jsonValue.isNumber()) {
+      throw new IllegalArgumentException("Json input value should be numeric");
+    }
     try {
       return jsonValue.asLong();
     } catch (NumberFormatException e) {

--- a/src/test/java/com/echobox/api/linkedin/util/JsonUtilsTest.java
+++ b/src/test/java/com/echobox/api/linkedin/util/JsonUtilsTest.java
@@ -46,7 +46,9 @@ public class JsonUtilsTest {
         + "       \"description\": \"content description\","
         + "       \"submitted-image-url\": \"https://ichef.bbci.co.uk/news/660/cpsprodpb"
         + "/13398/production/_104444787_whatsubject.jpg\""
-        + "    }"
+        + "    },"
+        + "   \"numbers\": {\"long\":523412423423, \"double\":2.434343423432, "
+        + "    \"int\": 42}"
         + "}";
     JsonObject asObject = Json.parse(json).asObject();
     Map<String, Object> map = JsonUtils.toMap(asObject);
@@ -63,6 +65,12 @@ public class JsonUtilsTest {
     assertEquals("content description", content.get("description"));
     assertEquals("https://ichef.bbci.co.uk/news/660/cpsprodpb/13398/production/_104444787_"
         + "whatsubject.jpg", content.get("submitted-image-url"));
+  
+    Map<String, Object> numbers = (Map) map.get("numbers");
+    assertEquals(42L, numbers.get("int"));
+    assertEquals(523412423423L, numbers.get("long"));
+    assertEquals(2.434343423432, numbers.get("double"));
+    
   }
 
 }


### PR DESCRIPTION
### Description of Changes

Fix the `JsonUtils.getValue` to return numeric values if the jsonvalue is a numeric one.

### Documentation

N/A

### Risks & Impacts

small as it will make sure we always use a number if the json value is a numeric one

### Testing

- manually
-  unit test


## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.