### PR TITLE
SL-1778 Add post comment functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,4 +118,5 @@ can get data for both organization and organization brand pages.
 * Updated `CommentAction.Attribute.value` to use AttributedEntity, to fix issue where share 
   requests with mentions aren't being persisted correctly.
 
-## 3.0.6 (work in progress)
+## 3.1.0 (Sep 7, 2022)
+* Add CommentConnection for posting comment to a post (by URN)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>3.0.6</version>
+  <version>3.1.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/CommentConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/CommentConnection.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.connection.v2;
+
+import com.echobox.api.linkedin.client.LinkedInClient;
+import com.echobox.api.linkedin.types.social.actions.CommentAction;
+import com.echobox.api.linkedin.types.social.actions.CommentResponse;
+import com.echobox.api.linkedin.types.urn.URN;
+
+/**
+ * Comment connection class for posting comments
+ *
+ * @author Kenneth Wong
+ *
+ */
+public class CommentConnection extends ConnectionBaseV2 {
+  
+  private static final String SOCIAL_ACTIONS_COMMENT = "/socialActions/%s/comments";
+  
+  /**
+   * Instantiates a new comment connection
+   *
+   * @param linkedinClient the LinkedIn client
+   */
+  public CommentConnection(LinkedInClient linkedinClient) {
+    super(linkedinClient);
+  }
+  
+  public CommentResponse postComment(CommentAction commentRequest, URN postURN) {
+    String path = String.format(SOCIAL_ACTIONS_COMMENT, postURN.toURLEncodedString());
+    return linkedinClient.publish(path, CommentResponse.class, commentRequest);
+  }
+}

--- a/src/main/java/com/echobox/api/linkedin/types/social/actions/CommentResponse.java
+++ b/src/main/java/com/echobox/api/linkedin/types/social/actions/CommentResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.social.actions;
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import com.echobox.api.linkedin.types.objectype.AuditStamp;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Response class for comment posting
+ * @author Kenneth Wong
+ */
+public class CommentResponse extends CommentAction {
+  
+  @Getter
+  @Setter
+  @LinkedIn
+  private AuditStamp created;
+  
+  @Getter
+  @Setter
+  @LinkedIn
+  private AuditStamp lastModified;
+  
+}

--- a/src/main/java/com/echobox/api/linkedin/types/urn/URN.java
+++ b/src/main/java/com/echobox/api/linkedin/types/urn/URN.java
@@ -22,6 +22,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 /**
  * The type Urn.
@@ -99,6 +101,15 @@ public class URN implements Serializable {
   @Override
   public String toString() {
     return "urn:li:" + entityType + ":" + id;
+  }
+  
+  public String toURLEncodedString() {
+    try {
+      return URLEncoder.encode(this.toString(), "UTF-8");
+    } catch (UnsupportedEncodingException ex) {
+      // return original string
+      return this.toString();
+    }
   }
   
   @Override

--- a/src/test/java/com/echobox/api/linkedin/types/social/actions/CommentResponseTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/social/actions/CommentResponseTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.social.actions;
+
+import static org.junit.Assert.assertEquals;
+
+import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapper;
+import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapperTestBase;
+import com.echobox.api.linkedin.types.objectype.AuditStamp;
+import org.junit.Test;
+
+public class CommentResponseTest extends DefaultJsonMapperTestBase {
+  
+  @Test
+  public void testCommentResponse() {
+    String json = readFileToString(
+        "com.echobox.api.linkedin.jsonmapper/commentResponse.json");
+    DefaultJsonMapper defaultJsonMapper = new DefaultJsonMapper();
+    CommentResponse response = defaultJsonMapper.toJavaObject(json, CommentResponse.class);
+    
+    final String actorURN = "urn:li:organization:5637409";
+    
+    assertEquals(actorURN, response.getActor().toString());
+    CommentAction.CommentMessage commentMessage = response.getMessage();
+    assertEquals("commentV2 with image urn", commentMessage.getText());
+  
+    AuditStamp created = response.getCreated();
+    assertEquals(actorURN, created.getActor());
+    assertEquals(1583863835990L, created.getTime().longValue());
+  
+    AuditStamp lastModified = response.getLastModified();
+    assertEquals(actorURN, lastModified.getActor());
+    assertEquals(1583863835991L, lastModified.getTime().longValue());
+  }
+}

--- a/src/test/resources/com.echobox.api.linkedin.jsonmapper/commentResponse.json
+++ b/src/test/resources/com.echobox.api.linkedin.jsonmapper/commentResponse.json
@@ -1,0 +1,30 @@
+{
+  "actor": "urn:li:organization:5637409",
+  "agent": "urn:li:person:CnpTkB7V70",
+  "created": {
+    "actor": "urn:li:organization:5637409",
+    "impersonator": "urn:li:person:CnpTkB7V70",
+    "time": 1583863835990
+  },
+  "id": "6643206422739898368",
+  "lastModified": {
+    "actor": "urn:li:organization:5637409",
+    "impersonator": "urn:li:person:CnpTkB7V70",
+    "time": 1583863835991
+  },
+  "message": {
+    "attributes": [],
+    "text": "commentV2 with image urn"
+  },
+  "$URN": "urn:li:comment:(urn:li:activity:6641861161010679808,6643206422739898368)",
+  "content": [
+    {
+      "type": "IMAGE",
+      "url": "https://media.licdn-ei.com/dms/image/C552CAQGu16obsGZENQ/comment-image-shrink_8192_800/0?e=1585180800&v=beta&t=d8E35ZP3x0_Lrk0utXbn3YPw9_5ybihj2AWXWb8xHdc",
+      "entity": {
+        "digitalmediaAsset": "urn:li:digitalmediaAsset:C552CAQGu16obsGZENQ"
+      }
+    }
+  ],
+  "object": "urn:li:activity:6641861161010679808"
+}


### PR DESCRIPTION
### Description of Changes
- Add CommentConnection for posting comment to post (by URN)
- Add CommentResponse for the response from comment endpoint

### Reference
https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/comments-api?view=li-lms-2022-08&tabs=http

### Documentation
N/A

### Risks & Impacts
- Should be no, as new version is not in use yet.

### Testing
- Have been done in spike ticket https://echobox.atlassian.net/browse/SL-1676
- Will test again when implementing changes in main

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.