### PR TITLE
SL-2042 Move gpg key imports to build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,12 +42,6 @@ jobs:
           name: "What branch am I on?"
           command: export SOURCE_BRANCH_NAME=$CIRCLE_BRANCH
       - run:
-          name: "Import GPG keys"
-          command: echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import || echo "Failed to import GPG_SECRET_KEYS (probably because this branch is a PR)."
-      - run:
-          name: "Import GPG owner trust"
-          command: echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust || echo "Failed to import GPG_OWNERTRUST (probably because this branch is a PR)."
-      - run:
           name: "Export version & Validate build"
           command: source buildscripts/exportMVNVersionWithSnapshotIfNotARelease.sh && source buildscripts/validateBuild.sh
   build:
@@ -55,6 +49,12 @@ jobs:
       image: ubuntu-2004:2022.07.1
     steps:
       - checkout
+      - run:
+          name: "Import GPG keys"
+          command: echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import || echo "Failed to import GPG_SECRET_KEYS (probably because this branch is a PR)."
+      - run:
+          name: "Import GPG owner trust"
+          command: echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust || echo "Failed to import GPG_OWNERTRUST (probably because this branch is a PR)."
       - run:
           name: "Run build script"
           command: source buildscripts/build.sh


### PR DESCRIPTION
### Description of Changes

GPG secret key imports & decoding moved to build step where they are required for use by `build.sh` script

### Documentation

N/A

### Risks & Impacts

No risks

### Testing

To be tested on PR merge

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.