### PR TITLE
SL-2042 Move GPG keys logic to build.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,12 +49,6 @@ jobs:
       image: ubuntu-2004:2022.07.1
     steps:
       - checkout
-      - run: |
-          if [ "$CIRCLE_BRANCH" == "$DEV_BRANCH" ] || [ "$CIRCLE_BRANCH" == "$RELEASE_BRANCH" ]; then
-              echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import --batch --passphrase $GPG_PASSPHRASE || echo "Failed to import GPG_SECRET_KEYS."
-              echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust || echo "Failed to import GPG_OWNERTRUST."
-              export GPG_TTY=$(tty)
-          fi
       - run:
           name: "Run build script"
           command: source buildscripts/build.sh

--- a/buildscripts/build.sh
+++ b/buildscripts/build.sh
@@ -20,6 +20,10 @@
 ## All other builds are simply verified
 if [ "$CIRCLE_BRANCH" == "$RELEASE_BRANCH" ] || [ "$CIRCLE_BRANCH" == "$DEV_BRANCH" ]; then
   printf "${GREEN_COLOUR}Performing deploy build to maven central.${NO_COLOUR}\n"
+  echo "${GPG_SECRET_KEYS}" | base64 --decode | $GPG_EXECUTABLE --import --batch --passphrase "${GPG_PASSPHRASE}" || echo "Failed to import GPG_SECRET_KEYS."
+  echo "${GPG_OWNERTRUST}" | base64 --decode | $GPG_EXECUTABLE --import-ownertrust || echo "Failed to import GPG_OWNERTRUST."
+  GPG_TTY=$(tty)
+  export GPG_TTY
   mvn clean deploy --settings .maven.xml -B -U -Prelease
 else
   printf "${GREEN_COLOUR}Performing a PR verify build. Releases are only created from $DEV_BRANCH and $RELEASE_BRANCH branches.${NO_COLOUR}\n"


### PR DESCRIPTION
### Description of Changes

GPG key imports moved to build.sh to avoid duplication of conditional logic and ensure variables are available to script

### Documentation

N/A

### Risks & Impacts

None

### Testing

Dev build to be tested after PR merge

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.