### PR TITLE
SL-2042 Ensure dev branch builds only deploy snapshot versions

### DIFF
--- a/buildscripts/build.sh
+++ b/buildscripts/build.sh
@@ -22,8 +22,12 @@ if [ "$CIRCLE_BRANCH" == "$RELEASE_BRANCH" ] || [ "$CIRCLE_BRANCH" == "$DEV_BRAN
   printf "${GREEN_COLOUR}Performing deploy build to maven central.${NO_COLOUR}\n"
   echo "${GPG_SECRET_KEYS}" | base64 --decode | $GPG_EXECUTABLE --import --batch --passphrase "${GPG_PASSPHRASE}" || echo "Failed to import GPG_SECRET_KEYS."
   echo "${GPG_OWNERTRUST}" | base64 --decode | $GPG_EXECUTABLE --import-ownertrust --batch --passphrase "${GPG_PASSPHRASE}" || echo "Failed to import GPG_OWNERTRUST."
-  GPG_TTY=$(tty)
-  export GPG_TTY
+  
+  if [ "$CIRCLE_BRANCH" == "$DEV_BRANCH" ]; then
+    MVN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout|grep -v '\[')
+    mvn versions:set -q -DnewVersion="$MVN_VERSION-SNAPSHOT"
+  fi
+
   mvn clean deploy --settings .maven.xml -B -U -Prelease
 else
   printf "${GREEN_COLOUR}Performing a PR verify build. Releases are only created from $DEV_BRANCH and $RELEASE_BRANCH branches.${NO_COLOUR}\n"


### PR DESCRIPTION
### Description of Changes

Snapshot versioning logic added to `build.sh` since `- checkout` in new jobs re-sources code from build branch and therefore overwrites version changes conducted in previous steps.

### Documentation

https://circleci.com/docs/configuration-reference#checkout

### Risks & Impacts

None

### Testing

To be tested on PR merge

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.