### PR TITLE
SL-2042 Run checkout step to source code in predeploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,11 +60,14 @@ jobs:
     machine:
       image: ubuntu-2004:2022.07.1
     steps:
+      - checkout
       - run: |
           if [ "$CIRCLE_BRANCH" != "$DEV_BRANCH" ] && [ "$CIRCLE_BRANCH" != "$RELEASE_BRANCH" ]; then
               circleci-agent step halt
           fi
-      - run: source buildscripts/exportMVNVersionWithSnapshotIfNotARelease.sh
+      - run: 
+          name: "Export maven version"
+          command: source buildscripts/exportMVNVersionWithSnapshotIfNotARelease.sh
       # Set up git user name and tag this commit
       - run: |
           git config --local user.name "MarcFletcher"

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>3.0.6</version>
+  <version>3.0.7</version>
   <packaging>jar</packaging>
 
   <properties>


### PR DESCRIPTION
### Description of Changes

Checkout step added to predeploy job to allow invocation of `exportMVNVersionWithSnapshotIfNotARelease.sh`
Named the step which calls the above script

### Documentation

https://circleci.com/docs/configuration-reference#checkout

### Risks & Impacts

None. Will allow script to be called so that mvn version can be used in `git tag $DEPLOY_TAG`

### Testing

To be tested on PR merge to dev

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.