### PR TITLE
Upgrade google-api-client dependency to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,3 +125,4 @@ can get data for both organization and organization brand pages.
 * Add CommentConnection for posting comment to a post (by URN)
 
 ## 3.1.1 (work in progress)
+* Add explicit dependency for google-api-client

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
       <version>v2-rev157-1.25.0</version>
     </dependency>
     <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.eclipsesource.minimal-json</groupId>
       <artifactId>minimal-json</artifactId>
       <version>0.9.5</version>

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -42,7 +42,7 @@ import com.google.api.client.http.MultipartContent;
 import com.google.api.client.http.json.JsonHttpContent;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.JsonObjectParser;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,7 +103,7 @@ public class DefaultWebRequestor implements WebRequestor {
    */
   private static final int DEFAULT_READ_TIMEOUT_IN_MS = 180000;
 
-  private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+  private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
 
   private Map<String, Object> currentHeaders;
 
@@ -626,7 +626,7 @@ public class DefaultWebRequestor implements WebRequestor {
     JsonObject asObject = Json.parse(jsonBody).asObject();
     Map<String, Object> map = JsonUtils.toMap(asObject);
   
-    return new JsonHttpContent(new JacksonFactory(), map);
+    return new JsonHttpContent(new GsonFactory(), map);
   }
   
   private void addHeadersToRequest(HttpRequest request, HttpHeaders httpHeaders,


### PR DESCRIPTION
### Description of Changes

Add google-api-client dependency at v2.0.0
Replace deprecated code

### Documentation

N/A

### Risks & Impacts

Potentially using code that has been deprecated in the later google-api-client version.

### Testing

Code compilation and passing unit tests should be sufficient.

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.