### PR TITLE
Revert "Bump checkstyle from 8.45 to 10.3.4 (#196)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.3.4</version>
+            <version>8.45</version>
           </dependency>
           <dependency>
             <groupId>com.github.sevntu-checkstyle</groupId>


### PR DESCRIPTION
### Description of Changes
This reverts commit 1e019d12f036c1976677de9c7be9d127e6bfc951.

### Documentation
### Risks & Impacts

### Testing

Compiles

### Compare (For layered PRs)

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.