### PR TITLE
SL-2567 - Include response body when raising an exception following a 422.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,4 +127,7 @@ can get data for both organization and organization brand pages.
 ## 3.1.1 (Sep 29, 2022)
 * Add explicit dependency for google-api-client
 
-## 3.1.2 (Work In Progress)
+## 3.1.2 (Oct 13, 2022)
+* Updated error handling so that the response body is included in the exception when a 422 error 
+  is received after a request to the LinkedIn API
+* Updated dependencies

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
@@ -41,11 +41,11 @@ import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
 import com.eclipsesource.json.ParseException;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -614,40 +614,40 @@ public class DefaultLinkedInClient extends BaseLinkedInClient implements LinkedI
     // or 401 Not Authorized or 403 Forbidden or 404 Not Found or 500 Internal
     // Server Error or 302 Not Modified or 504 Gateway Timeout or 422 Unprocessable Entity or 429
     // Rate Limit throw an exception.
-    if (HttpURLConnection.HTTP_OK != response.getStatusCode()
-        && HttpURLConnection.HTTP_CREATED != response.getStatusCode()
-        && HttpURLConnection.HTTP_NO_CONTENT != response.getStatusCode()
-        && HttpURLConnection.HTTP_BAD_REQUEST != response.getStatusCode()
-        && HttpURLConnection.HTTP_UNAUTHORIZED != response.getStatusCode()
-        && HttpURLConnection.HTTP_NOT_FOUND != response.getStatusCode()
-        && HttpURLConnection.HTTP_INTERNAL_ERROR != response.getStatusCode()
-        && HttpURLConnection.HTTP_FORBIDDEN != response.getStatusCode()
-        && HttpURLConnection.HTTP_NOT_MODIFIED != response.getStatusCode()
-        && HttpURLConnection.HTTP_GATEWAY_TIMEOUT != response.getStatusCode()
-        && 422 != response.getStatusCode()
-        && 429 != response.getStatusCode()) {
+    if (HttpStatus.SC_OK != response.getStatusCode()
+        && HttpStatus.SC_CREATED != response.getStatusCode()
+        && HttpStatus.SC_NO_CONTENT != response.getStatusCode()
+        && HttpStatus.SC_NOT_MODIFIED != response.getStatusCode()
+        && HttpStatus.SC_BAD_REQUEST != response.getStatusCode()
+        && HttpStatus.SC_UNAUTHORIZED != response.getStatusCode()
+        && HttpStatus.SC_FORBIDDEN != response.getStatusCode()
+        && HttpStatus.SC_NOT_FOUND != response.getStatusCode()
+        && HttpStatus.SC_UNPROCESSABLE_ENTITY != response.getStatusCode()
+        && HttpStatus.SC_TOO_MANY_REQUESTS != response.getStatusCode()
+        && HttpStatus.SC_INTERNAL_SERVER_ERROR != response.getStatusCode()
+        && HttpStatus.SC_GATEWAY_TIMEOUT != response.getStatusCode()) {
       throw new LinkedInNetworkException("LinkedIn request failed", response.getStatusCode());
     }
     
     String json = response.getBody();
     
     // If the response is 2XX then we do not need to throw an error response
-    if (HttpURLConnection.HTTP_OK != response.getStatusCode()
-        && HttpURLConnection.HTTP_CREATED != response.getStatusCode()
-        && HttpURLConnection.HTTP_NO_CONTENT != response.getStatusCode()) {
+    if (HttpStatus.SC_OK != response.getStatusCode()
+        && HttpStatus.SC_CREATED != response.getStatusCode()
+        && HttpStatus.SC_NO_CONTENT != response.getStatusCode()) {
       // If the response contained an error code, throw an exception.
       throwLinkedInResponseStatusExceptionIfNecessary(json, response.getStatusCode());
     }
     
     // If there was no response error information and this was a 500
     // error, something weird happened on LinkedIn's end. Bail.
-    if (HttpURLConnection.HTTP_INTERNAL_ERROR == response.getStatusCode()) {
+    if (HttpStatus.SC_INTERNAL_SERVER_ERROR == response.getStatusCode()) {
       throw new LinkedInNetworkException("LinkedIn request failed", response.getStatusCode());
     }
   
     // If there was no response error information and this was a 401
     // error, something weird happened on LinkedIn's end. Assume it is a Oauth error.
-    if (HttpURLConnection.HTTP_UNAUTHORIZED == response.getStatusCode()) {
+    if (HttpStatus.SC_UNAUTHORIZED == response.getStatusCode()) {
       throw new LinkedInOAuthException("LinkedIn request failed", response.getStatusCode());
     }
     

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
@@ -612,8 +612,8 @@ public class DefaultLinkedInClient extends BaseLinkedInClient implements LinkedI
     
     // If we get any HTTP response code other than a 200 OK or 400 Bad Request
     // or 401 Not Authorized or 403 Forbidden or 404 Not Found or 500 Internal
-    // Server Error or 302 Not Modified or 504 Gateway Timeout or 429 Rate Limit
-    // throw an exception.
+    // Server Error or 302 Not Modified or 504 Gateway Timeout or 422 Unprocessable Entity or 429
+    // Rate Limit throw an exception.
     if (HttpURLConnection.HTTP_OK != response.getStatusCode()
         && HttpURLConnection.HTTP_CREATED != response.getStatusCode()
         && HttpURLConnection.HTTP_NO_CONTENT != response.getStatusCode()
@@ -624,6 +624,7 @@ public class DefaultLinkedInClient extends BaseLinkedInClient implements LinkedI
         && HttpURLConnection.HTTP_FORBIDDEN != response.getStatusCode()
         && HttpURLConnection.HTTP_NOT_MODIFIED != response.getStatusCode()
         && HttpURLConnection.HTTP_GATEWAY_TIMEOUT != response.getStatusCode()
+        && 422 != response.getStatusCode()
         && 429 != response.getStatusCode()) {
       throw new LinkedInNetworkException("LinkedIn request failed", response.getStatusCode());
     }


### PR DESCRIPTION
### Description of Changes

Previously the request body of a 422 error was swallowed by the response handling code. This ensures that it isn't. The intention is to be able to get to the bottom of the 422 errors we are receiving, this is covered in [this](https://echobox.atlassian.net/browse/SL-2425) investigation.

This should be a patch version change. I will release this change after this PR goes in.

### Documentation

### Risks & Impacts

### Testing
No testing required.

### Compare (For layered PRs)

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.