### PR TITLE
SL-2607 Export mvn version in same step as build & deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,14 +23,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Export MVN version"
-          command: source buildscripts/exportMVNVersionWithSnapshotIfNotARelease.sh
-      - run:
           name: "Validate build"
-          command: source buildscripts/validateBuild.sh
+          command: source buildscripts/exportMVNVersionWithSnapshotIfNotARelease.sh && source buildscripts/validateBuild.sh
       - run:
           name: "Build (and deploy if dev/master)"
-          command: source buildscripts/build.sh
+          command: source buildscripts/exportMVNVersionWithSnapshotIfNotARelease.sh && source buildscripts/build.sh
       - run:
           name: "If failure"
           command: cat target/surefire-reports/*.txt


### PR DESCRIPTION
### Description of Changes

`exportMVNVersionWithSnapshotIfNotARelease.sh` called from deploy step, before `build.sh`. This is required to ensure version is set to `SNAPSHOT` before a PR merge to dev deployment.

### Documentation

N/A

### Risks & Impacts

None

### Testing

Tested on a previous config.yaml 

### Compare (For layered PRs)

N/A

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.