### PR TITLE
SL-2607 Only export version and append SNAPSHOT once, before deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - checkout
       - run:
           name: "Validate build"
-          command: source buildscripts/exportMVNVersionWithSnapshotIfNotARelease.sh && source buildscripts/validateBuild.sh
+          command: source buildscripts/validateBuild.sh
       - run:
           name: "Build (and deploy if dev/master)"
           command: source buildscripts/exportMVNVersionWithSnapshotIfNotARelease.sh && source buildscripts/build.sh

--- a/buildscripts/validateBuild.sh
+++ b/buildscripts/validateBuild.sh
@@ -17,23 +17,11 @@
 ##
 
 if [ "$CIRCLE_BRANCH" == "dev" ] || [ "$CIRCLE_BRANCH" == "master" ]; then
-  printf "${GREEN_COLOUR}Building base branch $CIRCLE_BRANCH which is at version $MVN_VERSION.${NO_COLOUR}\n"
+  printf "${GREEN_COLOUR}Building base branch $CIRCLE_BRANCH.${NO_COLOUR}\n"
 else
   #Get the PR title
   export PR_TITLE=$(curl -s https://api.github.com/repos/$REPO/pulls/${CIRCLE_PULL_REQUEST##*/} | grep -Po '(?<="title":[[:space:]]")[^"]*(?=",)')
 
   printf "${GREEN_COLOUR}Building PR #${CIRCLE_PULL_REQUEST##*/} '$PR_TITLE' from branch $CIRCLE_BRANCH (into $DEV_BRANCH)${NO_COLOUR}\n"
-  
-  ##Disabled as travis keeps getting rate limited by github
-  ##Ensure the PR name matches our expected format
-  #if ! [[ $PR_TITLE =~ ^[A-Z]{2,4}-[0-9]+[[:space:]].+$ ]]; then
-  #  printf "${RED_COLOUR}PR title '$PR_TITLE' does not match the expected format 'GH-[xxxx] [description]'.${NO_COLOUR}\n"
-  #  travis_terminate 1;
-  #fi
-  
-  #Ensure PR cannot be merged into master, unless it's coming from dev
-  # if [ "$CIRCLE_BRANCH" == "$RELEASE_BRANCH" ] && [ "$CIRCLE_BRANCH" != "$DEV_BRANCH" ]; then
-  #   printf "${RED_COLOUR}Build failed as PR target is master. Please ensure you use $DEV_BRANCH as the target.${NO_COLOUR}\n"
-  #   circleci-agent step halt;
-  # fi
+
 fi


### PR DESCRIPTION
### Description of Changes

First invocation of `exportMVNVersionWithSnapshotIfNotARelease.sh` removed
References to `$MVN_VERSION` removed from validateBuild.sh

### Documentation

N/A

### Risks & Impacts

None

### Testing

Tested on two previous PRs

### Compare (For layered PRs)

N/A

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.