### PR TITLE
SL-302 - Remove unused google-api-services-oauth2 dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,3 +136,5 @@ can get data for both organization and organization brand pages.
 * Add `application/x-wwww-form-urlenconded` header to obtain access token request and update additional header method to add headers as a list.
 
 ## 3.1.4 (Work In Progress)
+* Bump sl4j depenencies from 1.7.x to 2.0.x
+* Removed google-api-services-oauth2 dependency

--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-oauth2</artifactId>
-      <version>v2-rev157-1.25.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
       <version>2.0.0</version>


### PR DESCRIPTION
### Description of Changes

Removed dependency as it wasn't being used. Removes the need for this dependabot PR: https://github.com/ebx/ebx-linkedin-sdk/pull/197

### Documentation

### Risks & Impacts

It is silently being used somewhere. See Testing section.

### Testing

I have compiled the code and run all the tests. I also compiled the `main` repo maven project using this version and ran the Social API.

Please do consider whether this is fully tested!

### Compare (For layered PRs)

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.