### PR TITLE
SL-3755 find organization brand by parent organization URN

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
@@ -289,7 +289,6 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
     if (this.defaultHeaders == null) {
       this.defaultHeaders = new HashMap<>();
       this.defaultHeaders.put(HEADER_NAME_VERSION, versionedMonth);
-      this.defaultHeaders.put(HEADER_NAME_PROTOCOL, DEFAULT_LINKEDIN_PROTOCOL);
     }
   }
   

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
@@ -21,6 +21,7 @@ import com.echobox.api.linkedin.client.Parameter;
 import com.echobox.api.linkedin.client.VersionedLinkedInClient;
 import com.echobox.api.linkedin.types.organization.Organization;
 import com.echobox.api.linkedin.types.organization.OrganizationBase;
+import com.echobox.api.linkedin.types.organization.OrganizationBrand;
 import com.echobox.api.linkedin.types.organization.OrganizationResult;
 import com.echobox.api.linkedin.types.urn.URN;
 import com.echobox.api.linkedin.types.urn.URNEntityType;
@@ -51,12 +52,14 @@ public class VersionedOrganizationConnection extends VersionedConnection {
    */
   private static final String VANITY_NAME_KEY = "vanityName";
   private static final String EMAIL_DOMAIN_KEY = "emailDomain";
+  private static final String PARENT_KEY = "parent";
   
   /**
    * Param value
    */
   private static final String VANITY_NAME_VALUE = "vanityName";
   private static final String EMAIL_DOMAIN_VALUE = "emailDomain";
+  private static final String PARENT_ORGANIZATION_VALUE = "parentOrganization";
   
   /**
    * Instantiates a new connection base.
@@ -135,6 +138,25 @@ public class VersionedOrganizationConnection extends VersionedConnection {
         parameters.toArray(new Parameter[0]));
   }
   
+  /**
+   * Use organization parent URN to get a list of array of brands that belong to the specified
+   * parent
+   * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api?view=li-lms-2022-11&tabs=http#find-administered-organization-brands-by-parent-organization">
+   * Retrieve Organization Brand by Parent Organization</a>
+   * @param organizationURN parent organization URN
+   * @return all the organization brands
+   */
+  public List<OrganizationBrand> retrieveOrganizationBrandByParentOrganization(
+      URN organizationURN) {
+    validateOrganizationURN("organizationURN", organizationURN);
+    
+    List<Parameter> parameters = new ArrayList<>();
+    parameters.add(Parameter.with(QUERY_KEY, PARENT_ORGANIZATION_VALUE));
+    parameters.add(Parameter.with(PARENT_KEY, organizationURN.toString()));
+    
+    return getListFromQuery(ORGANIZATIONS, OrganizationBrand.class,
+        parameters.toArray(new Parameter[0]));
+  }
   
   // Validation
   private void validateOrganizationURN(String paramName, URN organizationURN) {


### PR DESCRIPTION
### Description of Changes
- Remove `X-Restli-Protocol-Version: 2.0.0` from default headers, as it is found that this endpoint cannot be performed with this
- Add `retrieveOrganizationBrandByParentOrganization `in `VersionedOrganizationConnection`

### Documentation
https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api?view=li-lms-2022-11&tabs=http#find-administered-organization-brands-by-parent-organization

### Risks & Impacts
- Little. It's new function.
- May affect previously developed functions.

### Testing
- Manually tested with below code snippet.
```
    List<OrganizationBrand> organizationsByParent =
        organizationConnection.retrieveOrganizationBrandByParentOrganization(
            new URN("urn:li:organization:88910959"));
    Optional.ofNullable(organizationsByParent).map(Collection::stream).orElseGet(Stream::empty)
        .map(gson::toJson).forEach(System.out::println);

```
Result:
```
{"localizedName":"Ewok Running Brand","name":{"localized":{"en_US":"Ewok Running Brand"},"preferredLocale":{"country":"US","language":"en"}},"vanityName":"ewok-running-brand","logoV2":{"cropInfo":{"height":0,"width":0,"xAxis":0,"yAxis":0},"cropped":{"entityType":"digitalmediaAsset","id":"D4E0BAQHlPQAYyELvyw"},"original":{"entityType":"digitalmediaAsset","id":"D4E0BAQHlPQAYyELvyw"}},"primaryOrganizationType":"BRAND","id":88912973}
```

Previously developed functions were tested again and successful

## Final Checklist

Please tick once completed.

- [x] Build passes.
