### PR TITLE
SL-3780 Create versioned comments connection

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedCommentConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedCommentConnection.java
@@ -40,7 +40,7 @@ public class VersionedCommentConnection extends VersionedConnection {
    *
    * @param linkedinClient the LinkedIn client
    */
-  protected VersionedCommentConnection(VersionedLinkedInClient linkedinClient) {
+  public VersionedCommentConnection(VersionedLinkedInClient linkedinClient) {
     super(linkedinClient);
   }
   

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedCommentConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedCommentConnection.java
@@ -28,7 +28,7 @@ import com.echobox.api.linkedin.types.urn.URN;
  * @author Sergio Abplanalp
  *
  */
-public class VersionedCommentsConnection extends VersionedConnection {
+public class VersionedCommentConnection extends VersionedConnection {
   
   /**
    * endpoint path
@@ -40,7 +40,7 @@ public class VersionedCommentsConnection extends VersionedConnection {
    *
    * @param linkedinClient the LinkedIn client
    */
-  protected VersionedCommentsConnection(VersionedLinkedInClient linkedinClient) {
+  protected VersionedCommentConnection(VersionedLinkedInClient linkedinClient) {
     super(linkedinClient);
   }
   

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedCommentsConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedCommentsConnection.java
@@ -22,6 +22,12 @@ import com.echobox.api.linkedin.types.social.actions.CommentAction;
 import com.echobox.api.linkedin.types.social.actions.CommentResponse;
 import com.echobox.api.linkedin.types.urn.URN;
 
+/**
+ * Comment connection class for posting comments
+ *
+ * @author Sergio Abplanalp
+ *
+ */
 public class VersionedCommentsConnection extends VersionedConnection {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedCommentsConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedCommentsConnection.java
@@ -15,30 +15,26 @@
  * limitations under the License.
  */
 
-package com.echobox.api.linkedin.connection.v2;
+package com.echobox.api.linkedin.connection.versioned;
 
-import com.echobox.api.linkedin.client.LinkedInClient;
+import com.echobox.api.linkedin.client.VersionedLinkedInClient;
 import com.echobox.api.linkedin.types.social.actions.CommentAction;
 import com.echobox.api.linkedin.types.social.actions.CommentResponse;
 import com.echobox.api.linkedin.types.urn.URN;
 
-/**
- * Comment connection class for posting comments
- *
- * @author Kenneth Wong
- *
- */
-@Deprecated
-public class CommentConnection extends ConnectionBaseV2 {
-  
-  private static final String SOCIAL_ACTIONS_COMMENT = "/socialActions/%s/comments";
+public class VersionedCommentsConnection extends VersionedConnection {
   
   /**
-   * Instantiates a new comment connection
+   * endpoint path
+   */
+  private static final String SOCIAL_ACTIONS_COMMENT = "/socialActions/%s/comments";
+
+  /**
+   * Instantiates a new versioned comment connection.
    *
    * @param linkedinClient the LinkedIn client
    */
-  public CommentConnection(LinkedInClient linkedinClient) {
+  protected VersionedCommentsConnection(VersionedLinkedInClient linkedinClient) {
     super(linkedinClient);
   }
   


### PR DESCRIPTION
### Description of Changes
- Create versioned comments connection class
- Copy `postComment` method from v2 to versioned comments connection class
- Tag v2 comment class as deprecated

### Documentation


### Risks & Impacts


### Testing
Manual testing
