### PR TITLE
SL-3758 add find AccessControl by URN

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
@@ -59,6 +59,7 @@ public class VersionedOrganizationConnection extends VersionedConnection {
   private static final String PARENT_KEY = "parent";
   private static final String ROLE_KEY = "role";
   private static final String STATE_KEY = "state";
+  private static final String ORGANIZATION_KEY = "organization";
   
   /**
    * Param value
@@ -67,6 +68,7 @@ public class VersionedOrganizationConnection extends VersionedConnection {
   private static final String EMAIL_DOMAIN_VALUE = "emailDomain";
   private static final String PARENT_ORGANIZATION_VALUE = "parentOrganization";
   private static final String ROLE_ASSIGNEE_VALUE = "roleAssignee";
+  private static final String ORGANIZATION_VALUE = "organization";
   
   /**
    * Instantiates a new connection base.
@@ -204,6 +206,32 @@ public class VersionedOrganizationConnection extends VersionedConnection {
     
     return getListFromQuery(ORGANIZATION_ACLS, AccessControl.class,
         params.toArray(new Parameter[0]));
+  }
+  
+  /**
+   * Find an Organization's Access Control Information
+   * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-access-control-by-role?view=li-lms-2022-11&tabs=http#find-organization-administrators">
+   * Access Control</a>
+   * @param organizationURN The organization for which access control information
+   * is retrieved.
+   * @param role Limit results to specific roles
+   * @param state Limit results to specific role states
+   * @param projection Field projection
+   * @param count the number of entries to be returned per paged request
+   * @return List of access controls for an organization
+   */
+  public List<AccessControl> findOrganizationAccessControl(URN organizationURN,
+      String role, String state, Parameter projection, Integer count) {
+    validateOrganizationURN("organization", organizationURN);
+    
+    List<Parameter> parameters = new ArrayList<>();
+    parameters.add(Parameter.with(QUERY_KEY, ORGANIZATION_VALUE));
+    parameters.add(Parameter.with(ORGANIZATION_KEY, organizationURN.toString()));
+    addRoleStateParams(role, state, projection, parameters);
+    addStartAndCountParams(parameters, null, count);
+    
+    return getListFromQuery(ORGANIZATION_ACLS, AccessControl.class,
+        parameters.toArray(new Parameter[0]));
   }
   
   // Validation


### PR DESCRIPTION
### Description of Changes
- Add `findOrganizationAccessControl()` to `VersionedOrganizationConnection`

### Documentation
https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-access-control-by-role?view=li-lms-2022-11&tabs=http#find-organization-administrators

### Risks & Impacts
- Little. A new function

### Testing
- Tested with below code snippet
```
  List<AccessControl> acl = organizationConnection.findOrganizationAccessControl(
      new URN("urn:li:organization:88910959"),
      "ADMINISTRATOR", "APPROVED", null, null);
  Optional.ofNullable(acl).map(Collection::stream).orElseGet(Stream::empty)
      .map(gson::toJson).forEach(System.out::println);

```
Result:
```
{"state":"APPROVED","role":"ADMINISTRATOR","roleAssigneeURN":{"entityType":"person","id":"sXD_V6IiPY"},"organizationURN":{"entityType":"organization","id":"88910959"}}

```
### Compare (For layered PRs)
https://github.com/ebx/ebx-linkedin-sdk/compare/SL-3757-organization-acl...SL-3758-get-acl-by-urn

Need to merge after https://github.com/ebx/ebx-linkedin-sdk/pull/258

## Final Checklist

Please tick once completed.

- [x] Build passes.
