### PR TITLE
SL-3761 Other work on organization endpoint

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
@@ -289,7 +289,6 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
     if (this.defaultHeaders == null) {
       this.defaultHeaders = new HashMap<>();
       this.defaultHeaders.put(HEADER_NAME_VERSION, versionedMonth);
-      this.defaultHeaders.put(HEADER_NAME_PROTOCOL, DEFAULT_LINKEDIN_PROTOCOL);
     }
   }
   

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
@@ -176,6 +176,8 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
    */
   protected boolean httpDeleteFallback = false;
   
+  private Map<String, String> defaultHeaders;
+  
   /**
    * Creates a LinkedIn API client with the given {@code accessToken}.
    *
@@ -284,6 +286,11 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
     this.apiVersion = apiVersion;
     this.linkedinExceptionMapper = linkedinExceptionMapper;
     this.versionedMonth = versionedMonth;
+    if (this.defaultHeaders == null) {
+      this.defaultHeaders = new HashMap<>();
+      this.defaultHeaders.put(HEADER_NAME_VERSION, versionedMonth);
+      this.defaultHeaders.put(HEADER_NAME_PROTOCOL, DEFAULT_LINKEDIN_PROTOCOL);
+    }
   }
   
   @Override
@@ -320,7 +327,7 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
       String pageURL = apiVersion.isSpecifyFormat()
           ? URLUtils.replaceOrAddQueryParameter(connectionPageUrl, "format", "json")
           : connectionPageUrl;
-      return webRequestor.executeGet(pageURL);
+      return webRequestor.executeGet(pageURL, defaultHeaders);
     });
     
     return new Connection<T>(connectionPageUrl, this, connectionJson, connectionType);
@@ -513,12 +520,9 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
     
     final String fullEndpoint = createEndpointForApiCall(endpoint,
         binaryAttachments != null && !binaryAttachments.isEmpty());
-    
-    Map<String, String> headers = new HashMap<>();
-    headers.put(HEADER_NAME_VERSION, versionedMonth);
-    headers.put(HEADER_NAME_PROTOCOL, DEFAULT_LINKEDIN_PROTOCOL);
+
     return makeRequestFull(fullEndpoint, executeAsPost, executeAsDelete, jsonBody,
-        headers, binaryAttachments, parameters);
+        defaultHeaders, binaryAttachments, parameters);
   }
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/ConnectionBaseV2.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/ConnectionBaseV2.java
@@ -34,6 +34,7 @@ import java.util.List;
  */
 public class ConnectionBaseV2 extends ConnectionBase {
 
+  // CPD-OFF
   /**
    * The query key.
    */
@@ -102,4 +103,6 @@ public class ConnectionBaseV2 extends ConnectionBase {
     ValidationUtils.verifyParameterPresence("share", shareURN);
     validateURN(URNEntityType.SHARE, shareURN);
   }
+  
+  // CPD-ON
 }

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
@@ -83,6 +83,7 @@ public class OrganizationConnection extends ConnectionBaseV2 {
    * Initialise an organization connection
    * @param linkedinClient the linkedIn API client to create a LinkedIn organization connection
    */
+  @Deprecated
   public OrganizationConnection(LinkedInClient linkedinClient) {
     super(linkedinClient);
   }

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedConnection.java
@@ -17,9 +17,13 @@
 
 package com.echobox.api.linkedin.connection.versioned;
 
+import com.echobox.api.linkedin.client.Parameter;
 import com.echobox.api.linkedin.client.VersionedLinkedInClient;
 import com.echobox.api.linkedin.connection.ConnectionBase;
+import com.echobox.api.linkedin.types.TimeInterval;
 import com.echobox.api.linkedin.version.Version;
+
+import java.util.List;
 
 /**
  * Base class for all connections using versioned API
@@ -32,6 +36,10 @@ public abstract class VersionedConnection extends ConnectionBase {
    */
   protected static final String QUERY_KEY = "q";
   
+  private static final String TIME_INTERVALS_GRANULARITY = "timeIntervals.timeGranularityType";
+  private static final String TIME_INTERVALS_START = "timeIntervals.timeRange.start";
+  private static final String TIME_INTERVALS_END = "timeIntervals.timeRange.end";
+  
   /**
    * Instantiates a new connection base.
    *
@@ -43,4 +51,35 @@ public abstract class VersionedConnection extends ConnectionBase {
       throw new IllegalArgumentException("The version of linkedInClient is not VERSIONED");
     }
   }
+  
+  /**
+   * Add time interval to parameters.
+   *
+   * @param params       the list of parameters
+   * @param timeInterval the time interval to add
+   */
+  protected void addTimeIntervalToParams(List<Parameter> params, TimeInterval timeInterval) {
+    if (timeInterval == null) {
+      return;
+    }
+    
+    if (timeInterval.getTimeGranularityType() != null) {
+      // Time restriction on retrieving share statistics
+      params.add(Parameter.with(TIME_INTERVALS_GRANULARITY, timeInterval.getTimeGranularityType()));
+      if (timeInterval.getTimeRange() != null) {
+        if (timeInterval.getTimeRange().getStart() != null
+            && timeInterval.getTimeRange().getEnd() != null) {
+          params.add(Parameter.with(TIME_INTERVALS_START, timeInterval.getTimeRange().getStart()));
+          params.add(Parameter.with(TIME_INTERVALS_END, timeInterval.getTimeRange().getEnd()));
+        }
+      } else {
+        throw new IllegalStateException(
+            "timeIntervals.timeRange cannot be null when " + "timeInterval is provided");
+      }
+    } else {
+      throw new IllegalStateException(
+          "timeIntervals.timeGranularityType cannot be null when " + "timeInterval is provided");
+    }
+  }
+  
 }

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedImageConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedImageConnection.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.connection.versioned;
+
+import com.echobox.api.linkedin.client.VersionedLinkedInClient;
+
+/**
+ * Images connection class to handle image operations
+ * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api">Images API</a>
+ *
+ * @author Sergio Abplanalp
+ *
+ */
+public class VersionedImageConnection extends VersionedConnection {
+  
+  /**
+   * endpoint path
+   */
+  private static final String IMAGES = "/images";
+  private static final String ACTION_KEY = "action";
+  private static final String INITIALIZE_UPLOAD = "initializeUpload";
+
+  /**
+   * Instantiates a new connection base.
+   *
+   * @param linkedinClient the LinkedIn client
+   */
+  protected VersionedImageConnection(VersionedLinkedInClient linkedinClient) {
+    super(linkedinClient);
+  }
+}

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
@@ -375,6 +375,42 @@ public class VersionedOrganizationConnection extends VersionedConnection {
         params.toArray(new Parameter[0]));
   }
   
+  /**
+   * Look up a member's positions and related organization IDs.
+   */
+  public void findOrganizationsAssociatedToMemberPosition() {
+    throw new UnsupportedOperationException("Operation is not implemented yet.");
+  }
+  
+  /**
+   * Use organization parent URN to get a list of array of brands that belong to the specified
+   * parent
+   * @param organizationId organization id
+   */
+  public void retrieveOrganizationMediaContent(long organizationId) {
+    throw new UnsupportedOperationException("Operation is not implemented yet.");
+  }
+  
+  /**
+   * Search for organizations
+   * @param searchTerm the search term
+   * @return a list of organizations that match the organization
+   */
+  public List<Organization> searchForOrganizations(String searchTerm) {
+    throw new UnsupportedOperationException("Operation is not implemented yet.");
+  }
+  
+  /**
+   * Retrieve organization brand page statistics
+   * @param organizationBrand the organization brand URN
+   * @param timeInterval the time interval for time bounded statistics
+   * @return list of page statistics for the organization brand
+   */
+  public List<Statistics.BrandStatistics> retrieveOrganizationBrandPageStatistics(
+      URN organizationBrand, TimeInterval timeInterval) {
+    throw new UnsupportedOperationException("Operation is not implemented yet.");
+  }
+  
   // Validation
   /**
    * Validate share urn.

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
@@ -46,6 +46,7 @@ public class VersionedOrganizationConnection extends VersionedConnection {
    * endpoint path
    */
   private static final String ORGANIZATIONS = "/organizations";
+  private static final String ORGANIZATIONS_BRANDS = "/organizationBrands";
   
   /**
    * Keys
@@ -139,6 +140,25 @@ public class VersionedOrganizationConnection extends VersionedConnection {
   }
   
   /**
+   * Use organization brand id to find all all of its information
+   * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api?view=li-lms-2022-11&tabs=http#retrieve-an-administered-organization-brand">
+   * Retrieve an organization brand</a>
+   * @param organizationBrandURN organizationBrandURN
+   * @param fields the fields to request
+   * @return the organization brand
+   */
+  public OrganizationBrand retrieveOrganizationBrand(URN organizationBrandURN, Parameter fields) {
+    validateOrganizationBrandURN("organizationBrandURN", organizationBrandURN);
+    List<Parameter> parameters = new ArrayList<>();
+    if (fields != null) {
+      parameters.add(fields);
+    }
+    String id = organizationBrandURN.getId();
+    return linkedinClient.fetchObject(ORGANIZATIONS_BRANDS + "/" + id,
+        OrganizationBrand.class, parameters.toArray(new Parameter[0]));
+  }
+  
+  /**
    * Use organization parent URN to get a list of array of brands that belong to the specified
    * parent
    * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api?view=li-lms-2022-11&tabs=http#find-administered-organization-brands-by-parent-organization">
@@ -163,6 +183,10 @@ public class VersionedOrganizationConnection extends VersionedConnection {
     validateURN(paramName, organizationURN, URNEntityType.ORGANIZATION);
     ValidationUtils.verifyParameterPresence(paramName, organizationURN);
     validateURN(URNEntityType.ORGANIZATION, organizationURN);
+  }
+  
+  private void validateOrganizationBrandURN(String paramName, URN organizationBrandURN) {
+    validateURN(paramName, organizationBrandURN, URNEntityType.ORGANIZATIONBRAND);
   }
   
   private void validateURN(String paramName, URN urn, URNEntityType type) {

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
@@ -21,6 +21,7 @@ import com.echobox.api.linkedin.client.Parameter;
 import com.echobox.api.linkedin.client.VersionedLinkedInClient;
 import com.echobox.api.linkedin.types.organization.Organization;
 import com.echobox.api.linkedin.types.organization.OrganizationBase;
+import com.echobox.api.linkedin.types.organization.OrganizationBrand;
 import com.echobox.api.linkedin.types.organization.OrganizationResult;
 import com.echobox.api.linkedin.types.urn.URN;
 import com.echobox.api.linkedin.types.urn.URNEntityType;
@@ -51,12 +52,14 @@ public class VersionedOrganizationConnection extends VersionedConnection {
    */
   private static final String VANITY_NAME_KEY = "vanityName";
   private static final String EMAIL_DOMAIN_KEY = "emailDomain";
+  private static final String PARENT_KEY = "parent";
   
   /**
    * Param value
    */
   private static final String VANITY_NAME_VALUE = "vanityName";
   private static final String EMAIL_DOMAIN_VALUE = "emailDomain";
+  private static final String PARENT_ORGANIZATION_VALUE = "parentOrganization";
   
   /**
    * Instantiates a new connection base.
@@ -135,6 +138,25 @@ public class VersionedOrganizationConnection extends VersionedConnection {
         parameters.toArray(new Parameter[0]));
   }
   
+  /**
+   * Use organization parent URN to get a list of array of brands that belong to the specified
+   * parent
+   * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api?view=li-lms-2022-11&tabs=http#find-administered-organization-brands-by-parent-organization">
+   * Retrieve Organization Brand by Parent Organization</a>
+   * @param organizationURN parent organization URN
+   * @return all the organization brands
+   */
+  public List<OrganizationBrand> retrieveOrganizationBrandByParentOrganization(
+      URN organizationURN) {
+    validateOrganizationURN("organizationURN", organizationURN);
+    
+    List<Parameter> parameters = new ArrayList<>();
+    parameters.add(Parameter.with(QUERY_KEY, PARENT_ORGANIZATION_VALUE));
+    parameters.add(Parameter.with(PARENT_KEY, organizationURN.toString()));
+    
+    return getListFromQuery(ORGANIZATIONS, OrganizationBrand.class,
+        parameters.toArray(new Parameter[0]));
+  }
   
   // Validation
   private void validateOrganizationURN(String paramName, URN organizationURN) {

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
@@ -50,11 +50,13 @@ public class VersionedOrganizationConnection extends VersionedConnection {
    * Keys
    */
   private static final String VANITY_NAME_KEY = "vanityName";
+  private static final String EMAIL_DOMAIN_KEY = "emailDomain";
   
   /**
    * Param value
    */
   private static final String VANITY_NAME_VALUE = "vanityName";
+  private static final String EMAIL_DOMAIN_VALUE = "emailDomain";
   
   /**
    * Instantiates a new connection base.
@@ -108,6 +110,31 @@ public class VersionedOrganizationConnection extends VersionedConnection {
     return organizationList.stream().map(OrganizationResult::getOrganization)
         .collect(Collectors.toList());
   }
+  
+  /**
+   * Lookup an organization by email domain
+   * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api?view=li-lms-2022-11&tabs=http#find-organization-by-email-domain">
+   * Find Organization by Email Domain</a>
+   * @param emailDomain the email domain for the organization
+   * @param fields the fields to request
+   * @param count the number of entries to be returned per paged request
+   * @return A list of organizations with the email domain
+   */
+  public List<Organization> findOrganizationByEmailDomain(String emailDomain, Parameter fields,
+      Integer count) {
+    ValidationUtils.verifyParameterPresence("emailDomain", emailDomain);
+    
+    List<Parameter> parameters = new ArrayList<>();
+    if (fields != null) {
+      parameters.add(fields);
+    }
+    parameters.add(Parameter.with(QUERY_KEY, EMAIL_DOMAIN_VALUE));
+    parameters.add(Parameter.with(EMAIL_DOMAIN_KEY, emailDomain));
+    addStartAndCountParams(parameters, null, count);
+    return getListFromQuery(ORGANIZATIONS, Organization.class,
+        parameters.toArray(new Parameter[0]));
+  }
+  
   
   // Validation
   private void validateOrganizationURN(String paramName, URN organizationURN) {

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
@@ -59,6 +59,7 @@ public class VersionedOrganizationConnection extends VersionedConnection {
   private static final String PARENT_KEY = "parent";
   private static final String ROLE_KEY = "role";
   private static final String STATE_KEY = "state";
+  private static final String ORGANIZATION_KEY = "organization";
   
   /**
    * Param value
@@ -67,6 +68,7 @@ public class VersionedOrganizationConnection extends VersionedConnection {
   private static final String EMAIL_DOMAIN_VALUE = "emailDomain";
   private static final String PARENT_ORGANIZATION_VALUE = "parentOrganization";
   private static final String ROLE_ASSIGNEE_VALUE = "roleAssignee";
+  private static final String ORGANIZATION_VALUE = "organization";
   
   /**
    * Instantiates a new connection base.
@@ -204,6 +206,32 @@ public class VersionedOrganizationConnection extends VersionedConnection {
     
     return getListFromQuery(ORGANIZATION_ACLS, AccessControl.class,
         params.toArray(new Parameter[0]));
+  }
+  
+  /**
+   * Find an Organization's Access Control Information
+   * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-access-control-by-role?view=li-lms-2022-11&tabs=http#find-organization-administrators">
+   * Access Control</a>
+   * @param organizationURN The organization for which access control information
+   * is retrieved.
+   * @param role Limit results to specific roles
+   * @param state Limit results to specific role states
+   * @param projection Field projection
+   * @param count the number of entries to be returned per paged request
+   * @return List of access controls for an organization
+   */
+  public List<AccessControl> findOrganizationAccessControl(URN organizationURN,
+      String role, String state, Parameter projection, Integer count) {
+    validateOrganizationURN("organization", organizationURN);
+    
+    List<Parameter> parameters = new ArrayList<>();
+    parameters.add(Parameter.with(QUERY_KEY, ORGANIZATION_VALUE));
+    parameters.add(Parameter.with(ORGANIZATION_KEY, organizationURN.toString()));
+    addRoleStateParams(role, state, projection, parameters);
+    addStartAndCountParams(parameters, null, count);
+    
+    return getListFromQuery(ORGANIZATION_ACLS, AccessControl.class,
+        parameters.toArray(new Parameter[0]));
   }
   
   // Validation

--- a/src/main/java/com/echobox/api/linkedin/types/images/InitializeUpload.java
+++ b/src/main/java/com/echobox/api/linkedin/types/images/InitializeUpload.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.images;
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import com.echobox.api.linkedin.types.urn.URN;
+import lombok.Getter;
+
+/**
+ * Register Upload Request body
+ * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api#initialize-image-upload">Initialize an Image Upload</a>
+ * @author Sergio Abplanalp
+ */
+public class InitializeUpload {
+  
+  @Getter
+  @LinkedIn
+  private InitializeUploadValue value;
+  
+  /**
+   * InitializeUploadValue object
+   * @author Sergio Abplanalp
+   */
+  public static class InitializeUploadValue {
+    @Getter
+    @LinkedIn
+    private Long uploadUrlExpiresAt;
+
+    @Getter
+    @LinkedIn
+    private String uploadUrl;
+
+    @Getter
+    @LinkedIn
+    private URN image;
+  }
+}

--- a/src/main/java/com/echobox/api/linkedin/types/images/InitializeUploadRequestBody.java
+++ b/src/main/java/com/echobox/api/linkedin/types/images/InitializeUploadRequestBody.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.images;
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import com.echobox.api.linkedin.types.urn.URN;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Register Upload Request body
+ * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api#initialize-image-upload">Initialize an Image Upload</a>
+ * @author Sergio Abplanalp
+ */
+@RequiredArgsConstructor
+public class InitializeUploadRequestBody {
+  
+  @NonNull
+  @Setter
+  @Getter
+  @LinkedIn
+  private InitializeUploadRequest initializeUploadRequest;
+  
+  /**
+   * InitializeUploadRequest object
+   * @author Sergio Abplanalp
+   */
+  @RequiredArgsConstructor
+  public static class InitializeUploadRequest {
+  
+    /**
+     * The URN of the entity that owns this asset
+     */
+    @NonNull
+    @Setter
+    @Getter
+    @LinkedIn
+    private URN owner;
+  }
+}


### PR DESCRIPTION
### Description of Changes
- Copy unsupported methods from `OrganizationConnection `(except `retrieveOrganizationBrandByVanityName()`, as brand can be retrieved by `findOrganizationByVanityName`
- Deprecate `OrganizationConnection`

### Documentation

Provide links to all relevant documentation that should be updated before asking for the PR to be reviewed. If this section is not relevant please write 'Not Applicable' rather than deleting the section.

### Risks & Impacts

The potential risks of this change as a bullet pointed list and how it might impact the wider sdk. Please consider how easily it would be to rollback these changes if they cause problems. Are there breaking changes?

### Testing

How have the changes been tested and the potential risks mitigated?

### Compare (For layered PRs)

Generate compare URL from https://github.com/ebx/ebx-linkedin-sdk/compare so that it's easily accessible. This is ONLY REQUIRED FOR COMPLICATED, DEPENDENT OR LAYERED PRs. Feel free to delete this section if not required.

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.