### PR TITLE
SL-4002 Remove redundant content-type header

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
@@ -324,7 +324,7 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
       String pageURL = apiVersion.isSpecifyFormat()
           ? URLUtils.replaceOrAddQueryParameter(connectionPageUrl, "format", "json")
           : connectionPageUrl;
-      return webRequestor.executeGet(pageURL, defaultHeaders);
+      return webRequestor.executeGet(pageURL);
     });
     
     return new Connection<T>(connectionPageUrl, this, connectionJson, connectionType);

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
@@ -519,7 +519,7 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
         binaryAttachments != null && !binaryAttachments.isEmpty());
 
     return makeRequestFull(fullEndpoint, executeAsPost, executeAsDelete, jsonBody,
-        defaultHeaders, binaryAttachments, parameters);
+        binaryAttachments, parameters);
   }
   
   /**
@@ -536,8 +536,6 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
    *          {@code true} to add a special 'treat this request as a {@code DELETE}' parameter.
    * @param jsonBody
    *          The POST JSON body
-   * @param headers
-   *          The headers for the request
    * @param binaryAttachments
    *          A list of binary files to include in a {@code POST} request. Pass {@code null} if no
    *          attachment should be sent.
@@ -546,7 +544,7 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
    * @return The JSON returned by LinkedIn for the API call.
    */
   protected String makeRequestFull(String fullEndpoint, final boolean executeAsPost,
-      final boolean executeAsDelete, Object jsonBody, Map<String, String> headers,
+      final boolean executeAsDelete, Object jsonBody,
       final List<BinaryAttachment> binaryAttachments, Parameter... parameters) {
     verifyParameterLegality(parameters);
     
@@ -567,15 +565,15 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
       @Override
       public WebRequestor.Response makeRequest() throws IOException {
         if (executeAsDelete && !isHttpDeleteFallback()) {
-          return webRequestor.executeDelete(fullEndpoint + finalParameterString, headers);
+          return webRequestor.executeDelete(fullEndpoint + finalParameterString, defaultHeaders);
         } else {
           return executeAsPost
               ? webRequestor.executePost(fullEndpoint, parameterString,
               jsonBody == null ? null : jsonMapper.toJson(jsonBody, true),
-              headers,
+              defaultHeaders,
               binaryAttachments == null ? null
                   : binaryAttachments.toArray(new BinaryAttachment[binaryAttachments.size()]))
-              : webRequestor.executeGet(fullEndpoint + finalParameterString, headers);
+              : webRequestor.executeGet(fullEndpoint + finalParameterString, defaultHeaders);
         }
       }
     });

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
@@ -176,7 +176,7 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
    */
   protected boolean httpDeleteFallback = false;
   
-  private Map<String, String> defaultHeaders;
+  private final Map<String, String> defaultHeaders = new HashMap<>();
   
   /**
    * Creates a LinkedIn API client with the given {@code accessToken}.
@@ -286,11 +286,8 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
     this.apiVersion = apiVersion;
     this.linkedinExceptionMapper = linkedinExceptionMapper;
     this.versionedMonth = versionedMonth;
-    if (this.defaultHeaders == null) {
-      this.defaultHeaders = new HashMap<>();
-      this.defaultHeaders.put(HEADER_NAME_VERSION, versionedMonth);
-      this.defaultHeaders.put(HEADER_NAME_PROTOCOL, DEFAULT_LINKEDIN_PROTOCOL);
-    }
+    this.defaultHeaders.put(HEADER_NAME_VERSION, versionedMonth);
+    this.defaultHeaders.put(HEADER_NAME_PROTOCOL, DEFAULT_LINKEDIN_PROTOCOL);
   }
   
   @Override

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
@@ -176,6 +176,8 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
    */
   protected boolean httpDeleteFallback = false;
   
+  private Map<String, String> defaultHeaders;
+  
   /**
    * Creates a LinkedIn API client with the given {@code accessToken}.
    *
@@ -284,6 +286,11 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
     this.apiVersion = apiVersion;
     this.linkedinExceptionMapper = linkedinExceptionMapper;
     this.versionedMonth = versionedMonth;
+    if (this.defaultHeaders == null) {
+      this.defaultHeaders = new HashMap<>();
+      this.defaultHeaders.put(HEADER_NAME_VERSION, versionedMonth);
+      this.defaultHeaders.put(HEADER_NAME_PROTOCOL, DEFAULT_LINKEDIN_PROTOCOL);
+    }
   }
   
   @Override
@@ -320,7 +327,7 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
       String pageURL = apiVersion.isSpecifyFormat()
           ? URLUtils.replaceOrAddQueryParameter(connectionPageUrl, "format", "json")
           : connectionPageUrl;
-      return webRequestor.executeGet(pageURL);
+      return webRequestor.executeGet(pageURL, defaultHeaders);
     });
     
     return new Connection<T>(connectionPageUrl, this, connectionJson, connectionType);
@@ -513,12 +520,9 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
     
     final String fullEndpoint = createEndpointForApiCall(endpoint,
         binaryAttachments != null && !binaryAttachments.isEmpty());
-    
-    Map<String, String> headers = new HashMap<>();
-    headers.put(HEADER_NAME_VERSION, versionedMonth);
-    headers.put(HEADER_NAME_PROTOCOL, DEFAULT_LINKEDIN_PROTOCOL);
+
     return makeRequestFull(fullEndpoint, executeAsPost, executeAsDelete, jsonBody,
-        headers, binaryAttachments, parameters);
+        defaultHeaders, binaryAttachments, parameters);
   }
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
@@ -519,7 +519,7 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
         binaryAttachments != null && !binaryAttachments.isEmpty());
 
     return makeRequestFull(fullEndpoint, executeAsPost, executeAsDelete, jsonBody,
-        binaryAttachments, parameters);
+        defaultHeaders, binaryAttachments, parameters);
   }
   
   /**
@@ -536,6 +536,8 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
    *          {@code true} to add a special 'treat this request as a {@code DELETE}' parameter.
    * @param jsonBody
    *          The POST JSON body
+   * @param headers
+   *          The headers for the request
    * @param binaryAttachments
    *          A list of binary files to include in a {@code POST} request. Pass {@code null} if no
    *          attachment should be sent.
@@ -544,7 +546,7 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
    * @return The JSON returned by LinkedIn for the API call.
    */
   protected String makeRequestFull(String fullEndpoint, final boolean executeAsPost,
-      final boolean executeAsDelete, Object jsonBody,
+      final boolean executeAsDelete, Object jsonBody, Map<String, String> headers,
       final List<BinaryAttachment> binaryAttachments, Parameter... parameters) {
     verifyParameterLegality(parameters);
     
@@ -565,15 +567,15 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
       @Override
       public WebRequestor.Response makeRequest() throws IOException {
         if (executeAsDelete && !isHttpDeleteFallback()) {
-          return webRequestor.executeDelete(fullEndpoint + finalParameterString, defaultHeaders);
+          return webRequestor.executeDelete(fullEndpoint + finalParameterString, headers);
         } else {
           return executeAsPost
               ? webRequestor.executePost(fullEndpoint, parameterString,
               jsonBody == null ? null : jsonMapper.toJson(jsonBody, true),
-              defaultHeaders,
+              headers,
               binaryAttachments == null ? null
                   : binaryAttachments.toArray(new BinaryAttachment[binaryAttachments.size()]))
-              : webRequestor.executeGet(fullEndpoint + finalParameterString, defaultHeaders);
+              : webRequestor.executeGet(fullEndpoint + finalParameterString, headers);
         }
       }
     });

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -347,9 +347,6 @@ public class DefaultWebRequestor implements WebRequestor {
         if (jsonBody != null) {
           request = requestFactory.buildPutRequest(genericUrl, getJsonHttpContent(jsonBody));
         
-          // Ensure the headers are set to JSON
-          httpHeaders.setContentType(CONTENT_TYPE).set(FORMAT_HEADER, "json");
-        
           // Ensure the response headers are also set to JSON
           request.setResponseHeaders(new HttpHeaders().set(FORMAT_HEADER, "json"));
         } else {


### PR DESCRIPTION
### Description of Changes
- Add default headers for all requests

According to the [LinkedIn API docs](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api): 
> All APIs require the request headers LinkedIn-Version: {Version in YYYYMM format} and X-Restli-Protocol-Version: 2.0.0

- Remove the setting of `content-type` header

### Documentation
We need to remove the `content-type` header from being set in `DefaultWebRequestor`. The header is currently being set by `google-http-client` in `HttpRequest` line 980.

With the previous API, it seems LinkedIn did not throw errors based on multiple headers of the same key. However, the new API throws a 400 Bad Request if there are multiple headers of the same key.

### Risks & Impacts

### Testing
Manually tested previous and new API versions locally.


### Compare (For layered PRs)

Generate compare URL from https://github.com/ebx/ebx-linkedin-sdk/compare so that it's easily accessible. This is ONLY REQUIRED FOR COMPLICATED, DEPENDENT OR LAYERED PRs. Feel free to delete this section if not required.

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.