### PR TITLE
SL-4002 Remove redundant http header

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -94,8 +94,6 @@ public class DefaultWebRequestor implements WebRequestor {
    */
   public static final String ENCODING_CHARSET = "UTF-8";
   
-  private static final String CONTENT_TYPE = "application/json";
-  
   private static final String FORMAT_HEADER = "x-li-format";
 
   /**
@@ -278,9 +276,6 @@ public class DefaultWebRequestor implements WebRequestor {
       } else {
         if (jsonBody != null) {
           request = requestFactory.buildPostRequest(genericUrl, getJsonHttpContent(jsonBody));
-
-          // Ensure the headers are set to JSON
-          httpHeaders.setContentType(CONTENT_TYPE).set(FORMAT_HEADER, "json");
 
           // Ensure the response headers are also set to JSON
           request.setResponseHeaders(new HttpHeaders().set(FORMAT_HEADER, "json"));


### PR DESCRIPTION
### Description of Changes
- Remove the setting of `content-type` header

### Documentation
We need to remove the `content-type` header from being set in `DefaultWebRequestor`. The header is currently being set by `google-http-client` in `HttpRequest` line 980.

With the previous API, it seems LinkedIn did not throw errors based on multiple headers of the same key. However, the new API throws a 400 Bad Request if there are multiple headers of the same key.

### Risks & Impacts

### Testing
Manually tested previous and new API versions locally.


### Compare (For layered PRs)

Generate compare URL from https://github.com/ebx/ebx-linkedin-sdk/compare so that it's easily accessible. This is ONLY REQUIRED FOR COMPLICATED, DEPENDENT OR LAYERED PRs. Feel free to delete this section if not required.

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.