### PR TITLE
SL-3771 retrieve posts by author

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedPostConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedPostConnection.java
@@ -17,12 +17,16 @@
 
 package com.echobox.api.linkedin.connection.versioned;
 
+import com.echobox.api.linkedin.client.Connection;
 import com.echobox.api.linkedin.client.Parameter;
 import com.echobox.api.linkedin.client.VersionedLinkedInClient;
 import com.echobox.api.linkedin.types.posts.Post;
 import com.echobox.api.linkedin.types.posts.ViewContext;
 import com.echobox.api.linkedin.types.urn.URN;
 import com.echobox.api.linkedin.util.URLUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Post connection
@@ -36,8 +40,18 @@ public class VersionedPostConnection extends VersionedConnection {
    * endpoint path
    */
   private static final String POSTS = "/posts";
+  
+  /**
+   * keys
+   */
+  private static final String KEY_AUTHOR = "author";
   private static final String VIEW_CONTEXT = "viewContext";
-
+  
+  /**
+   * Param
+   */
+  private static final String PARAM_AUTHOR = "author";
+  
   /**
    * Instantiates a new connection base.
    *
@@ -58,5 +72,14 @@ public class VersionedPostConnection extends VersionedConnection {
     Parameter viewContextParam = Parameter.with(VIEW_CONTEXT, viewContext);
     return linkedinClient.fetchObject(POSTS + "/" + URLUtils.urlDecode(shareURN.toString()),
         Post.class, viewContextParam);
+  }
+  
+  public Connection<Post> retrievePostsByAuthor(URN authorURN, Integer count) {
+    List<Parameter> parameters = new ArrayList<>();
+    parameters.add(Parameter.with(QUERY_KEY, KEY_AUTHOR));
+    parameters.add(Parameter.with(PARAM_AUTHOR, authorURN));
+    addStartAndCountParams(parameters, null, count);
+    return linkedinClient.fetchConnection(POSTS, Post.class,
+        parameters.toArray(new Parameter[parameters.size()]));
   }
 }


### PR DESCRIPTION
### Description of Changes
- Add retrievePostsByAuthor() in VersionedPostConnection

### Documentation
https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/posts-api#get-posts-by-urn

### Risks & Impacts
- Little. It's new function
- Sorting is not supported for Posts API (it was supported in UGC Posts). Some changes may be required when migration
  - It looks like sorted descending by created/published/last modified time

### Testing
- Manually tested with below code snippet.
```
    Connection<Post> postPages = postConnection.retrievePostsByAuthor(bioChemicalURN, 20);
    List<Post> posts = postPages.getData();
    Optional.ofNullable(posts).map(Collection::stream).orElseGet(Stream::empty)
        .map(gson::toJson).forEach(System.out::println);
```
Result:
```
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1672942841425,"publishedAt":1672942841425,"lastModifiedAt":1672942841425,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":" ","content":{"media":{"id":{"entityType":"image","id":"C4D22AQF9X-6pcsrtDA"}}},"visibility":"PUBLIC","id":{"entityType":"share","id":"7016830850965094401"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1672921429453,"publishedAt":1672921429453,"lastModifiedAt":1672921429506,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":" ","content":{},"visibility":"PUBLIC","id":{"entityType":"share","id":"7016741042397822977"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1672859158561,"publishedAt":1672859158561,"lastModifiedAt":1672859163670,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"Hello! \n{hashtag|\\#|building} {hashtag|\\#|village}","content":{},"visibility":"PUBLIC","id":{"entityType":"share","id":"7016479859174465536"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1672853830213,"publishedAt":1672853830213,"lastModifiedAt":1672853830266,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"I am test number 4","visibility":"PUBLIC","id":{"entityType":"share","id":"7016457511083880448"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1672843059173,"publishedAt":1672843059173,"lastModifiedAt":1672843059223,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"I am test number 3","visibility":"PUBLIC","id":{"entityType":"share","id":"7016412333937704960"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1672842398730,"publishedAt":1672842398730,"lastModifiedAt":1672842398782,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"I am test number 2","visibility":"PUBLIC","id":{"entityType":"share","id":"7016409564019372032"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1672830706259,"publishedAt":1672830706259,"lastModifiedAt":1672830706259,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"I am a test","visibility":"PUBLIC","id":{"entityType":"share","id":"7016360522144976896"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1672767720848,"publishedAt":1672767720848,"lastModifiedAt":1672767720848,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":" ","content":{"media":{"id":{"entityType":"image","id":"C4D22AQGIv0ye4iSa9A"}}},"visibility":"PUBLIC","id":{"entityType":"share","id":"7016096342041092096"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1672755829680,"publishedAt":1672755829680,"lastModifiedAt":1672755829680,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"I am a test","visibility":"PUBLIC","id":{"entityType":"share","id":"7016046467060494337"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1672416708414,"publishedAt":1672416708414,"lastModifiedAt":1672416708581,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"Brazil begins its first day of mourning the late footballing legend as landmarks are lit up in tribute.","content":{},"visibility":"PUBLIC","id":{"entityType":"share","id":"7014624088941826048"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1671448929408,"publishedAt":1671448929408,"lastModifiedAt":1671448930539,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"It was one of the greatest finals in World Cup history, so how did the \"breathless\" showpiece unfold?","content":{},"visibility":"PUBLIC","id":{"entityType":"share","id":"7010564929506185216"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1671214618043,"publishedAt":1671214618043,"lastModifiedAt":1671214618043,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"Hello","visibility":"PUBLIC","id":{"entityType":"share","id":"7009582156926611456"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1671213078358,"publishedAt":1671213078358,"lastModifiedAt":1671213078358,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":" ","visibility":"PUBLIC","id":{"entityType":"share","id":"7009575698994491392"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1671211852897,"publishedAt":1671211852897,"lastModifiedAt":1671211852974,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":" ","content":{},"visibility":"PUBLIC","id":{"entityType":"share","id":"7009570558564544512"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1671194429001,"publishedAt":1671194429001,"lastModifiedAt":1671194429001,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"I am text","visibility":"PUBLIC","id":{"entityType":"share","id":"7009497477917609984"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1671187844848,"publishedAt":1671187844848,"lastModifiedAt":1671187849979,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"Robert Williams will reportedly make his season debut on Friday when the Boston Celtics host the Orlando Magic according to multiple reports.","content":{},"visibility":"PUBLIC","id":{"entityType":"share","id":"7009469861617635328"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1671108851626,"publishedAt":1671108851626,"lastModifiedAt":1671108854786,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"The New York Knicks discussed trading Evan Fournier in return for Los Angles Lakers guards Patrick Beverley and Kendrick Nunn, but talks have stalled.","content":{},"visibility":"PUBLIC","id":{"entityType":"share","id":"7009138539858653184"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1671107144120,"publishedAt":1671107144120,"lastModifiedAt":1671107145331,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"He is accused of \"orchestrating a scheme\" to defraud investors in failed crypto exchange FTX.","content":{},"visibility":"PUBLIC","id":{"entityType":"share","id":"7009131378147520512"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1669114197425,"publishedAt":1669114197425,"lastModifiedAt":1669114197477,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"Bio Chemicals London - more chemicals\nBio Chemicals London - more chemicals\nBio Chemicals London - more chemicals\nwow","content":{"media":{"id":{"entityType":"image","id":"C4D22AQGCZJRX5N4cZA"}}},"visibility":"PUBLIC","id":{"entityType":"share","id":"7000772354146512896"}}
{"author":{"entityType":"organization","id":"19049739"},"createdAt":1668520573260,"publishedAt":1668520573260,"lastModifiedAt":1668520576404,"distribution":{"distributedViaFollowFeed":false},"lifecycleStateInfo":{"isEditedByAuthor":false},"lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false,"commentary":"El Real Madrid ganó con justicia y autoridad la Supercopa de España disputada en Riad. Sin embargo, el verdadero ganador del torneo es el príncipe heredero","content":{},"visibility":"PUBLIC","id":{"entityType":"share","id":"6998282513605419008"}}

```


### Compare (For layered PRs)

Generate compare URL from https://github.com/ebx/ebx-linkedin-sdk/compare so that it's easily accessible. This is ONLY REQUIRED FOR COMPLICATED, DEPENDENT OR LAYERED PRs. Feel free to delete this section if not required.

## Final Checklist

Please tick once completed.

- [x] Build passes.
