### PR TITLE
SL-3779 Add delete post function to VersionedPostConnection

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedPostConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedPostConnection.java
@@ -74,6 +74,16 @@ public class VersionedPostConnection extends VersionedConnection {
         Post.class, viewContextParam);
   }
   
+  /**
+   * Retrieve posts by author (organization)
+   * @see
+   *
+   * <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/posts-api?view=li-lms-2022-12&tabs=http#find-posts-by-authors">Find Posts by Authors</a>
+   *
+   * @param authorURN author of the post - Posts author Organization
+   * @param count page count
+   * @return Connection object of the posts by the author
+   */
   public Connection<Post> retrievePostsByAuthor(URN authorURN, Integer count) {
     List<Parameter> parameters = new ArrayList<>();
     parameters.add(Parameter.with(QUERY_KEY, KEY_AUTHOR));
@@ -82,4 +92,14 @@ public class VersionedPostConnection extends VersionedConnection {
     return linkedinClient.fetchConnection(POSTS, Post.class,
         parameters.toArray(new Parameter[parameters.size()]));
   }
+  
+  /**
+   * Delete Posts
+   * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/posts-api?view=li-lms-2022-12&tabs=http#delete-posts">Delete Posts</a>
+   * @param shareURN the share URN of the share to delete - can be either a UGC share or share URN
+   */
+  public void deletePost(URN shareURN) {
+    linkedinClient.deleteObject(POSTS + "/" + URLUtils.urlEncode(shareURN.toString()));
+  }
+  
 }


### PR DESCRIPTION
### Description of Changes
- Add VersionedPostConnection.deletePost()

### Documentation
https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/posts-api?view=li-lms-2022-12&tabs=http#delete-posts

### Risks & Impacts
Little. New function

### Testing
Manual testing
```
    VersionedLinkedInClient client = new DefaultVersionedLinkedInClient(authToken);
    VersionedPostConnection postConnection = new VersionedPostConnection(client);
    postConnection.deletePost(new URN("urn:li:share:7017192031940751360"));

```
Checked the post was removed.

### Compare (For layered PRs)

Generate compare URL from https://github.com/ebx/ebx-linkedin-sdk/compare so that it's easily accessible. This is ONLY REQUIRED FOR COMPLICATED, DEPENDENT OR LAYERED PRs. Feel free to delete this section if not required.

## Final Checklist

Please tick once completed.

- [x] Build passes.
