### PR TITLE
SL-3779 add unit tests for post and image upload pojos

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/connection/v2/ShareConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/ShareConnection.java
@@ -34,6 +34,7 @@ import java.util.List;
  * @author joanna
  *
  */
+@Deprecated
 public class ShareConnection extends ConnectionBaseV2 {
   
   private static final String SHARES = "/shares";

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/UGCShareConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/UGCShareConnection.java
@@ -36,6 +36,7 @@ import java.util.List;
  * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api">UGC Shares</a>
  * @author joanna
  */
+@Deprecated
 public class UGCShareConnection extends ConnectionBaseV2 {
   
   private static final String UGC_POST = "/ugcPosts";

--- a/src/main/java/com/echobox/api/linkedin/types/images/InitializeUploadRequestBody.java
+++ b/src/main/java/com/echobox/api/linkedin/types/images/InitializeUploadRequestBody.java
@@ -20,6 +20,7 @@ package com.echobox.api.linkedin.types.images;
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 import com.echobox.api.linkedin.types.urn.URN;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -30,6 +31,7 @@ import lombok.Setter;
  * @author Sergio Abplanalp
  */
 @RequiredArgsConstructor
+@NoArgsConstructor
 public class InitializeUploadRequestBody {
   
   @NonNull
@@ -43,6 +45,7 @@ public class InitializeUploadRequestBody {
    * @author Sergio Abplanalp
    */
   @RequiredArgsConstructor
+  @NoArgsConstructor
   public static class InitializeUploadRequest {
   
     /**

--- a/src/main/java/com/echobox/api/linkedin/types/images/InitializeUploadRequestBody.java
+++ b/src/main/java/com/echobox/api/linkedin/types/images/InitializeUploadRequestBody.java
@@ -19,6 +19,7 @@ package com.echobox.api.linkedin.types.images;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 import com.echobox.api.linkedin.types.urn.URN;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -31,7 +32,7 @@ import lombok.Setter;
  * @author Sergio Abplanalp
  */
 @RequiredArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class InitializeUploadRequestBody {
   
   @NonNull
@@ -45,7 +46,7 @@ public class InitializeUploadRequestBody {
    * @author Sergio Abplanalp
    */
   @RequiredArgsConstructor
-  @NoArgsConstructor
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
   public static class InitializeUploadRequest {
   
     /**

--- a/src/test/java/com/echobox/api/linkedin/types/image/ImageUploadTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/image/ImageUploadTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.image;
+
+import static org.junit.Assert.assertEquals;
+
+import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapper;
+import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapperTestBase;
+import com.echobox.api.linkedin.types.images.InitializeUpload;
+import com.echobox.api.linkedin.types.images.InitializeUploadRequestBody;
+import com.echobox.api.linkedin.types.urn.URN;
+import org.junit.Test;
+
+public class ImageUploadTest extends DefaultJsonMapperTestBase {
+  
+  @Test
+  public void testInitializeUpload() {
+    String json = readFileToString("com.echobox.api.linkedin.jsonmapper/initializeUpload.json");
+    DefaultJsonMapper defaultJsonMapper = new DefaultJsonMapper();
+    InitializeUpload initializeUpload =
+        defaultJsonMapper.toJavaObject(json, InitializeUpload.class);
+  
+    InitializeUpload.InitializeUploadValue value = initializeUpload.getValue();
+    assertEquals(1650567510704L, value.getUploadUrlExpiresAt().longValue());
+    assertEquals("https://www.linkedin.com/dms-uploads/C4E10AQFoyyAjHPMQuQ/uploaded-image/0?ca"
+        + "=vector_ads&cn=uploads&sync=0&v=beta&ut=08zHQjMjAOLqc1", value.getUploadUrl());
+    assertEquals(new URN("urn:li:image:C4E10AQFoyyAjHPMQuQ"), value.getImage());
+  }
+  
+  @Test
+  public void testInitializeUploadRequestBody() {
+    String json = readFileToString(
+        "com.echobox.api.linkedin.jsonmapper/initializeUploadRequest.json");
+    DefaultJsonMapper defaultJsonMapper = new DefaultJsonMapper();
+    InitializeUploadRequestBody initializeUploadRequestBody =
+        defaultJsonMapper.toJavaObject(json, InitializeUploadRequestBody.class);
+    
+    assertEquals(new URN("urn:li:organization:5583111"),
+        initializeUploadRequestBody.getInitializeUploadRequest().getOwner());
+  }
+  
+}

--- a/src/test/java/com/echobox/api/linkedin/types/post/PostTest.java
+++ b/src/test/java/com/echobox/api/linkedin/types/post/PostTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.post;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapper;
+import com.echobox.api.linkedin.jsonmapper.DefaultJsonMapperTestBase;
+import com.echobox.api.linkedin.types.posts.AdContext;
+import com.echobox.api.linkedin.types.posts.Distribution;
+import com.echobox.api.linkedin.types.posts.Post;
+import com.echobox.api.linkedin.types.urn.URN;
+import org.junit.Test;
+
+public class PostTest extends DefaultJsonMapperTestBase {
+  
+  @Test
+  public void testPost() {
+    String json = readFileToString("com.echobox.api.linkedin.jsonmapper/post.json");
+    DefaultJsonMapper defaultJsonMapper = new DefaultJsonMapper();
+    Post post = defaultJsonMapper.toJavaObject(json, Post.class);
+    
+    assertEquals(Post.LifecycleState.PUBLISHED, post.getLifecycleState());
+    assertEquals(1634790968775L, post.getLastModifiedAt().longValue());
+    assertEquals(Post.Visibility.PUBLIC, post.getVisibility());
+    assertEquals(1634790968774L, post.getPublishedAt().longValue());
+    assertEquals(new URN("urn:li:organization:5515715"), post.getAuthor());
+    
+    assertEquals(Distribution.FeedDistribution.NONE, post.getDistribution().getFeedDistribution());
+    assertTrue(post.getDistribution().getThirdPartyDistributionChannels().isEmpty());
+    
+    assertEquals(new URN("urn:li:video:C5F10AQGKQg_6y2a4sQ"),
+        post.getContent().getMedia().getId());
+    
+    assertFalse(post.getLifecycleStateInfo().isEditedByAuthor());
+    assertFalse(post.isReshareDisabledByAuthor());
+    assertEquals(1634790968743L, post.getCreatedAt().longValue());
+    assertEquals(new URN("urn:li:share:6844785523593134080"), post.getId());
+    assertEquals("comment on Oct 20", post.getCommentary());
+    
+    assertEquals(AdContext.Status.ACTIVE, post.getAdContext().getDscStatus());
+    assertEquals(AdContext.AdType.VIDEO, post.getAdContext().getDscAdType());
+    assertTrue(post.getAdContext().isDsc());
+    assertEquals(new URN("urn:li:sponsoredAccount:520866471"),
+        post.getAdContext().getDscAdAccount());
+  }
+}

--- a/src/test/resources/com.echobox.api.linkedin.jsonmapper/initializeUpload.json
+++ b/src/test/resources/com.echobox.api.linkedin.jsonmapper/initializeUpload.json
@@ -1,0 +1,7 @@
+{
+  "value": {
+    "uploadUrlExpiresAt": 1650567510704,
+    "uploadUrl": "https://www.linkedin.com/dms-uploads/C4E10AQFoyyAjHPMQuQ/uploaded-image/0?ca=vector_ads&cn=uploads&sync=0&v=beta&ut=08zHQjMjAOLqc1",
+    "image": "urn:li:image:C4E10AQFoyyAjHPMQuQ"
+  }
+}

--- a/src/test/resources/com.echobox.api.linkedin.jsonmapper/initializeUploadRequest.json
+++ b/src/test/resources/com.echobox.api.linkedin.jsonmapper/initializeUploadRequest.json
@@ -1,0 +1,5 @@
+{
+  "initializeUploadRequest": {
+    "owner": "urn:li:organization:5583111"
+  }
+}

--- a/src/test/resources/com.echobox.api.linkedin.jsonmapper/post.json
+++ b/src/test/resources/com.echobox.api.linkedin.jsonmapper/post.json
@@ -1,0 +1,29 @@
+{
+  "lifecycleState": "PUBLISHED",
+  "lastModifiedAt": 1634790968775,
+  "visibility": "PUBLIC",
+  "publishedAt": 1634790968774,
+  "author": "urn:li:organization:5515715",
+  "distribution": {
+    "feedDistribution": "NONE",
+    "thirdPartyDistributionChannels": []
+  },
+  "content": {
+    "media": {
+      "id": "urn:li:video:C5F10AQGKQg_6y2a4sQ"
+    }
+  },
+  "lifecycleStateInfo": {
+    "isEditedByAuthor": false
+  },
+  "isReshareDisabledByAuthor": false,
+  "createdAt": 1634790968743,
+  "id": "urn:li:share:6844785523593134080",
+  "commentary": "comment on Oct 20",
+  "adContext": {
+    "dscStatus": "ACTIVE",
+    "dscAdType": "VIDEO",
+    "isDsc": true,
+    "dscAdAccount": "urn:li:sponsoredAccount:520866471"
+  }
+}


### PR DESCRIPTION
### Description of Changes
- Add unit tests for post and image upload POJOs
- Add no arg constructor to `initializeUploadRequestBody `(and its inner class)
- Deprecate `ShareConnection `& `UGCShareConnection`

### Documentation
N/A

### Risks & Impacts
- Should be no. Tests only

### Testing
- The change itself

### Compare (For layered PRs)

Generate compare URL from https://github.com/ebx/ebx-linkedin-sdk/compare so that it's easily accessible. This is ONLY REQUIRED FOR COMPLICATED, DEPENDENT OR LAYERED PRs. Feel free to delete this section if not required.

## Final Checklist

Please tick once completed.

- [x] Build passes.
