### PR TITLE
SL-4163 Fix response header mapping

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -55,7 +55,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.security.GeneralSecurityException;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -574,9 +576,23 @@ public class DefaultWebRequestor implements WebRequestor {
    */
   protected Response fetchResponse(int statusCode, HttpHeaders headers, String body) {
     Map<String, String> headerMap = headers.entrySet().stream()
-        .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toString(),
-            (key, value) -> value));
+            .collect(Collectors.toMap(Map.Entry::getKey, headerValueMapper()));
     return new Response(statusCode, headerMap, body);
+  }
+  
+  private Function<Map.Entry<String, Object>, String> headerValueMapper() {
+    return entry -> {
+      List<Object> value = (List<Object>) entry.getValue();
+      if (value == null || value.isEmpty()) {
+        return "";
+      }
+  
+      if (value.size() == 1) {
+        return value.get(0).toString();
+      }
+  
+      return value.toString();
+    };
   }
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -55,7 +55,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.security.GeneralSecurityException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -55,6 +55,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -580,10 +581,14 @@ public class DefaultWebRequestor implements WebRequestor {
     return new Response(statusCode, headerMap, body);
   }
   
-  private Function<Map.Entry<String, Object>, String> headerValueMapper() {
+  protected Function<Map.Entry<String, Object>, String> headerValueMapper() {
     return entry -> {
+      if (!(entry.getValue() instanceof List)) {
+        return entry.getValue().toString();
+      }
+      
       List<Object> value = (List<Object>) entry.getValue();
-      if (value == null || value.isEmpty()) {
+      if (value.isEmpty()) {
         return "";
       }
   


### PR DESCRIPTION
### Description of Changes
- Move `toString` call on array list object to first element in array list (if it only contains one element)

### Documentation

### Risks & Impacts
Low - changes to `DefaultWebRequestor` but headers are not being used anywhere currently

### Testing
Tested manually

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.