### PR TITLE
SL-3777 Add method to fill link post data

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/util/PostUtils.java
+++ b/src/main/java/com/echobox/api/linkedin/util/PostUtils.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 public abstract class PostUtils {
   
   /**
-   * Helper function for creating activ
+   * Helper function for filling article content to post
    * @param post post to be filled
    * @param articleUrl link of the article
    * @param thumbnail thumbnail image as ImageURN

--- a/src/main/java/com/echobox/api/linkedin/util/PostUtils.java
+++ b/src/main/java/com/echobox/api/linkedin/util/PostUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.util;
+
+import com.echobox.api.linkedin.types.posts.ArticleContent;
+import com.echobox.api.linkedin.types.posts.Content;
+import com.echobox.api.linkedin.types.posts.Post;
+import com.echobox.api.linkedin.types.urn.URN;
+import org.apache.commons.lang3.StringUtils;
+
+public abstract class PostUtils {
+  
+  /**
+   * Helper function for creating activ
+   * @param post post to be filled
+   * @param articleUrl link of the article
+   * @param thumbnail thumbnail image as ImageURN
+   * @param title title
+   * @param description description
+   */
+  public static void fillArticleContent(Post post, String articleUrl, URN thumbnail, String title,
+      String description) {
+    if (post == null || StringUtils.isBlank(articleUrl)) {
+      throw new IllegalArgumentException("Post and articleUrl must be provided");
+    }
+    Content content = new Content();
+    ArticleContent article = new ArticleContent();
+    article.setSource(articleUrl);
+    article.setThumbnail(thumbnail);
+    article.setTitle(title);
+    article.setDescription(description);
+    content.setArticle(article);
+    post.setContent(content);
+  }
+  
+  private PostUtils() {}
+}


### PR DESCRIPTION
### Description of Changes
- Add a new utility class (PostUtils) to fill link post data

### Documentation
N/A

### Risks & Impacts
No. Just a new method.

### Testing
Manual testing
  
```
    Distribution distribution = new Distribution(Distribution.FeedDistribution.MAIN_FEED);
    String commentary = "Paul George, who missed the previous five games after tweaking a "
        + "hamstring injury, returned to the lineup Tuesday night, but the Clippers fell to their"
        + " eighth loss in 10 games. - from SDK 2";
    Post post = new Post(bioChemicalURN, commentary, distribution, Post.LifecycleState.PUBLISHED,
        Post.Visibility.PUBLIC);
    URN preloadedURN = new URN("urn:li:image:C4D10AQEUTYPZ4rv2_w");
    String articleLink = "https://www.espn.co.uk/nba/story/_/id/35469012/george-returns-lineup"
        + "-clippers-play-host-76ers?utm_medium=Social&utm_source=LinkedIn#Echobox=1674039366";
    String title = "George returns in Clips' loss, preaches urgency - from SDK 2";
    String description = "no description";
    PostUtils.fillArticleContent(post, articleLink, preloadedURN, title, description);
    
    URN postURN = postConnection.createPost(post);
    System.out.println("created post: " + postURN);
```
Result: https://www.linkedin.com/feed/update/urn:li:share:7021456332998197248

I have no idea where description will be displayed. Schema:
https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/advertising-targeting/version/article-ads-integrations?view=li-lms-2023-01&tabs=http#schema

### Compare (For layered PRs)

Generate compare URL from https://github.com/ebx/ebx-linkedin-sdk/compare so that it's easily accessible. This is ONLY REQUIRED FOR COMPLICATED, DEPENDENT OR LAYERED PRs. Feel free to delete this section if not required.

## Final Checklist

Please tick once completed.

- [x] Build passes.
