### PR TITLE
SL-3781 Update versioning month the latest and deprecate v2 connections

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
@@ -59,6 +59,7 @@ import java.util.Map;
  * @author Joanna
  *
  */
+@Deprecated
 public class DefaultLinkedInClient extends BaseLinkedInClient implements LinkedInClient {
   // off code duplication check, as this will be removed when migration completed
   // CPD-OFF

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
@@ -128,7 +128,7 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
   /**
    * Default LinkedIn-version header
    */
-  public static final String DEFAULT_VERSIONED_MONTH = "202211";
+  public static final String DEFAULT_VERSIONED_MONTH = "202301";
   
   /**
    * Request header of protocol

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/ConnectionBaseV2.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/ConnectionBaseV2.java
@@ -32,6 +32,7 @@ import java.util.List;
  * Connection base for all V2 connections
  * @author joanna
  */
+@Deprecated
 public class ConnectionBaseV2 extends ConnectionBase {
 
   // CPD-OFF

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/OrganizationConnection.java
@@ -51,6 +51,7 @@ import java.util.stream.Collectors;
 
 // Ignore CPD as this will be removed after migration
 // CPD-OFF
+@Deprecated
 public class OrganizationConnection extends ConnectionBaseV2 {
   
   private static final String ORGANIZATION_ACLS = "/organizationAcls";
@@ -83,7 +84,6 @@ public class OrganizationConnection extends ConnectionBaseV2 {
    * Initialise an organization connection
    * @param linkedinClient the linkedIn API client to create a LinkedIn organization connection
    */
-  @Deprecated
   public OrganizationConnection(LinkedInClient linkedinClient) {
     super(linkedinClient);
   }


### PR DESCRIPTION
### Description of Changes
- Update versioning month to the latest `202301`
- Deprecate v2 connection classes

Note: Version bump will be done in subsequent PR.

### Documentation
N/A

### Risks & Impacts
- Little. It would be tested again when we use the new version

### Testing
- Ran some functions and the result is the same as before
```
    String vanityName = "bio-chemicals-london";
    List<OrganizationBase> organizations =
        organizationConnection.findOrganizationByVanityName(vanityName, null,
        10);
    Organization organization = organizationConnection.retrieveOrganization(
        new URN("urn:li:organization:19049739"),null);
    String emailDomain = "nike.com";
    List<Organization> organizationsByDomain =
        organizationConnection.findOrganizationByEmailDomain(emailDomain, null, 10);

```


### Compare (For layered PRs)

Generate compare URL from https://github.com/ebx/ebx-linkedin-sdk/compare so that it's easily accessible. This is ONLY REQUIRED FOR COMPLICATED, DEPENDENT OR LAYERED PRs. Feel free to delete this section if not required.

## Final Checklist

Please tick once completed.

- [x] Build passes.
