### PR TITLE
SL-4280 Add boolean support to JsonUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,3 +147,4 @@ can get data for both organization and organization brand pages.
 * Deprecated V2 connection classes
 
 ## 4.0.1 (Work in progress)
+* Add boolean support to JsonUtils

--- a/src/main/java/com/echobox/api/linkedin/util/JsonUtils.java
+++ b/src/main/java/com/echobox/api/linkedin/util/JsonUtils.java
@@ -67,6 +67,8 @@ public abstract class JsonUtils {
       value = jsonValue.asString();
     } else if (jsonValue.isNumber()) {
       value = getNumber(jsonValue);
+    } else if (jsonValue.isBoolean()) {
+      value = jsonValue.asBoolean();
     }
     return value;
   }

--- a/src/test/java/com/echobox/api/linkedin/util/JsonUtilsTest.java
+++ b/src/test/java/com/echobox/api/linkedin/util/JsonUtilsTest.java
@@ -18,6 +18,8 @@
 package com.echobox.api.linkedin.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
@@ -71,6 +73,24 @@ public class JsonUtilsTest {
     assertEquals(523412423423L, numbers.get("long"));
     assertEquals(2.434343423432, numbers.get("double"));
     
+  }
+  
+  @Test
+  public void testJsonWithBooleanValues() {
+    String json = "{ \"initializeUploadRequest\": {\n"
+        + "       \"owner\": \"urn:li:organization:2414183\",\n"
+        + "       \"fileSizeBytes\": 1055736 ,\n" + "       \"uploadCaptions\": false,\n"
+        + "       \"uploadThumbnail\": true\n" + "}\n" + "}";
+  
+    JsonObject asObject = Json.parse(json).asObject();
+    Map<String, Object> map = JsonUtils.toMap(asObject);
+    Map<String, Object> initializeUploadRequest = (Map) map.get("initializeUploadRequest");
+    assertEquals("urn:li:organization:2414183", initializeUploadRequest.get("owner"));
+    assertEquals(1055736L, initializeUploadRequest.get("fileSizeBytes"));
+    assertFalse((Boolean) initializeUploadRequest.get("uploadCaptions"));
+    assertTrue((Boolean) initializeUploadRequest.get("uploadThumbnail"));
+  
+  
   }
 
 }

--- a/src/test/java/com/echobox/api/linkedin/util/JsonUtilsTest.java
+++ b/src/test/java/com/echobox/api/linkedin/util/JsonUtilsTest.java
@@ -89,8 +89,6 @@ public class JsonUtilsTest {
     assertEquals(1055736L, initializeUploadRequest.get("fileSizeBytes"));
     assertFalse((Boolean) initializeUploadRequest.get("uploadCaptions"));
     assertTrue((Boolean) initializeUploadRequest.get("uploadThumbnail"));
-  
-  
   }
 
 }


### PR DESCRIPTION
### Description of Changes
- Add boolean support to JsonUtils

### Related issue
https://github.com/ebx/ebx-linkedin-sdk/issues/274

### Documentation
N/A

### Risks & Impacts
- Little. Just add support to boolean

### Testing
- Unit test added
 
### Compare (For layered PRs)

Generate compare URL from https://github.com/ebx/ebx-linkedin-sdk/compare so that it's easily accessible. This is ONLY REQUIRED FOR COMPLICATED, DEPENDENT OR LAYERED PRs. Feel free to delete this section if not required.

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.