### PR TITLE
SL-4532 Mark deprecated classes

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
@@ -123,7 +123,7 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
   /**
    * Default LinkedIn-version header
    */
-  public static final String DEFAULT_VERSIONED_MONTH = "202301";
+  public static final String DEFAULT_VERSIONED_MONTH = "202211";
   
   /**
    * Request header of protocol

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedPostConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedPostConnection.java
@@ -78,7 +78,7 @@ public class VersionedPostConnection extends VersionedConnection {
    */
   public Post retrievePost(URN shareURN, ViewContext viewContext) {
     Parameter viewContextParam = Parameter.with(VIEW_CONTEXT, viewContext);
-    return linkedinClient.fetchObject(POSTS + "/" + URLUtils.urlDecode(shareURN.toString()),
+    return linkedinClient.fetchObject(POSTS + "/" + URLUtils.urlEncode(shareURN.toString()),
         Post.class, viewContextParam);
   }
   

--- a/src/main/java/com/echobox/api/linkedin/types/AdminLevelType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/AdminLevelType.java
@@ -22,6 +22,7 @@ package com.echobox.api.linkedin.types;
  * @author joanna
  *
  */
+@Deprecated
 public enum AdminLevelType {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/Annotation.java
+++ b/src/main/java/com/echobox/api/linkedin/types/Annotation.java
@@ -28,6 +28,7 @@ import lombok.Setter;
  * @author joanna
  *
  */
+@Deprecated
 public class Annotation {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ContentEntity.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ContentEntity.java
@@ -31,6 +31,7 @@ import java.util.List;
  * @author joanna
  *
  */
+@Deprecated
 public class ContentEntity {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/DistributionTarget.java
+++ b/src/main/java/com/echobox/api/linkedin/types/DistributionTarget.java
@@ -31,6 +31,7 @@ import java.util.List;
  * @author joanna
  *
  */
+@Deprecated
 public class DistributionTarget {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ImageSpecificContent.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ImageSpecificContent.java
@@ -25,6 +25,7 @@ import lombok.Getter;
  * @author joanna
  *
  */
+@Deprecated
 public class ImageSpecificContent {
   
   @Getter

--- a/src/main/java/com/echobox/api/linkedin/types/LinkedInIdAndNameType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/LinkedInIdAndNameType.java
@@ -26,6 +26,7 @@ import lombok.Setter;
  * @author Joanna
  *
  */
+@Deprecated
 public abstract class LinkedInIdAndNameType extends LinkedInIdType {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/RichMediaLocation.java
+++ b/src/main/java/com/echobox/api/linkedin/types/RichMediaLocation.java
@@ -25,6 +25,7 @@ import lombok.Getter;
  * Rich media location type
  * @author joanna
  */
+@Deprecated
 public class RichMediaLocation {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/Share.java
+++ b/src/main/java/com/echobox/api/linkedin/types/Share.java
@@ -29,6 +29,7 @@ import lombok.Setter;
  * @author joanna
  *
  */
+@Deprecated
 public class Share extends LinkedInIdType {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ShareContent.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ShareContent.java
@@ -30,6 +30,7 @@ import java.util.List;
  * @author joanna
  *
  */
+@Deprecated
 public class ShareContent {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ShareDistribution.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ShareDistribution.java
@@ -26,6 +26,7 @@ import lombok.Setter;
  * @author joanna
  *
  */
+@Deprecated
 public class ShareDistribution {
   
   @Getter

--- a/src/main/java/com/echobox/api/linkedin/types/ShareMediaCategory.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ShareMediaCategory.java
@@ -22,6 +22,7 @@ package com.echobox.api.linkedin.types;
  * @author joanna
  *
  */
+@Deprecated
 public enum ShareMediaCategory {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ShareText.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ShareText.java
@@ -30,6 +30,7 @@ import java.util.List;
  * @author joanna
  *
  */
+@Deprecated
 public class ShareText {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/Thumbnail.java
+++ b/src/main/java/com/echobox/api/linkedin/types/Thumbnail.java
@@ -27,6 +27,7 @@ import java.util.List;
  * @author joanna
  *
  */
+@Deprecated
 public class Thumbnail {
   
   @Getter

--- a/src/main/java/com/echobox/api/linkedin/types/UGCPostsSortBy.java
+++ b/src/main/java/com/echobox/api/linkedin/types/UGCPostsSortBy.java
@@ -22,6 +22,7 @@ package com.echobox.api.linkedin.types;
  * @author Christopher Lyall
  *
  */
+@Deprecated
 public enum UGCPostsSortBy {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/assets/CheckStatusUpload.java
+++ b/src/main/java/com/echobox/api/linkedin/types/assets/CheckStatusUpload.java
@@ -28,6 +28,7 @@ import java.util.List;
  * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/vector-asset-api#check-status-of-upload">Check Status of Upload</a>
  * @author Joanna
  */
+@Deprecated
 public class CheckStatusUpload {
 
   @Getter

--- a/src/main/java/com/echobox/api/linkedin/types/assets/CompleteMultiPartUploadBody.java
+++ b/src/main/java/com/echobox/api/linkedin/types/assets/CompleteMultiPartUploadBody.java
@@ -33,6 +33,7 @@ import java.util.List;
  * @author Joanna
  */
 @RequiredArgsConstructor
+@Deprecated
 public class CompleteMultiPartUploadBody {
   
   @NonNull

--- a/src/main/java/com/echobox/api/linkedin/types/assets/RegisterUpload.java
+++ b/src/main/java/com/echobox/api/linkedin/types/assets/RegisterUpload.java
@@ -28,6 +28,7 @@ import java.util.Map;
  * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/vector-asset-api#register-an-upload">Register an Upload</a>
  * @author Joanna
  */
+@Deprecated
 public class RegisterUpload {
   
   @Getter

--- a/src/main/java/com/echobox/api/linkedin/types/assets/RegisterUploadRequestBody.java
+++ b/src/main/java/com/echobox/api/linkedin/types/assets/RegisterUploadRequestBody.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
  * @author Joanna
  */
 @RequiredArgsConstructor
+@Deprecated
 public class RegisterUploadRequestBody {
   
   @NonNull

--- a/src/main/java/com/echobox/api/linkedin/types/assets/RelationshipType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/assets/RelationshipType.java
@@ -21,6 +21,7 @@ package com.echobox.api.linkedin.types.assets;
  * Relationship type
  * @author Joanna
  */
+@Deprecated
 public enum RelationshipType {
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/objectype/AuditStamp.java
+++ b/src/main/java/com/echobox/api/linkedin/types/objectype/AuditStamp.java
@@ -27,6 +27,7 @@ import lombok.Getter;
  * @author joanna
  *
  */
+@Deprecated
 public class AuditStamp {
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/objectype/AuditStamp.java
+++ b/src/main/java/com/echobox/api/linkedin/types/objectype/AuditStamp.java
@@ -27,7 +27,6 @@ import lombok.Getter;
  * @author joanna
  *
  */
-@Deprecated
 public class AuditStamp {
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationRelationshipType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationRelationshipType.java
@@ -22,6 +22,7 @@ package com.echobox.api.linkedin.types.organization;
  * @author joanna
  *
  */
+@Deprecated
 public enum OrganizationRelationshipType {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationRole.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationRole.java
@@ -24,6 +24,7 @@ package com.echobox.api.linkedin.types.organization;
  * @author joanna
  *
  */
+@Deprecated
 public enum OrganizationRole {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationStatus.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationStatus.java
@@ -22,6 +22,7 @@ package com.echobox.api.linkedin.types.organization;
  * @author joanna
  *
  */
+@Deprecated
 public enum OrganizationStatus {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/OrganizationType.java
@@ -22,6 +22,7 @@ package com.echobox.api.linkedin.types.organization;
  * @author joanna
  *
  */
+@Deprecated
 public enum OrganizationType {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/organization/RelationshipStatus.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/RelationshipStatus.java
@@ -22,6 +22,7 @@ package com.echobox.api.linkedin.types.organization;
  * @author joanna
  *
  */
+@Deprecated
 public enum RelationshipStatus {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/organization/SchoolHierarchyClassification.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/SchoolHierarchyClassification.java
@@ -23,6 +23,7 @@ package com.echobox.api.linkedin.types.organization;
  * @author joanna
  *
  */
+@Deprecated
 public enum SchoolHierarchyClassification {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/organization/SchoolType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/SchoolType.java
@@ -23,6 +23,7 @@ package com.echobox.api.linkedin.types.organization;
  * @author joanna
  *
  */
+@Deprecated
 public enum SchoolType {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/organization/SchoolYearLevel.java
+++ b/src/main/java/com/echobox/api/linkedin/types/organization/SchoolYearLevel.java
@@ -25,6 +25,7 @@ package com.echobox.api.linkedin.types.organization;
  * @author joanna
  *
  */
+@Deprecated
 public enum SchoolYearLevel {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/request/PatchBody.java
+++ b/src/main/java/com/echobox/api/linkedin/types/request/PatchBody.java
@@ -26,6 +26,7 @@ import lombok.Data;
  * @author joanna
  */
 @Data
+@Deprecated
 public class PatchBody {
 
   @LinkedIn("$set")

--- a/src/main/java/com/echobox/api/linkedin/types/request/ShareRequestBody.java
+++ b/src/main/java/com/echobox/api/linkedin/types/request/ShareRequestBody.java
@@ -33,6 +33,7 @@ import lombok.Setter;
  * @author joanna
  */
 @RequiredArgsConstructor
+@Deprecated
 public class ShareRequestBody {
   
   private ShareRequestBody() {}

--- a/src/main/java/com/echobox/api/linkedin/types/request/UpdateShareRequestBody.java
+++ b/src/main/java/com/echobox/api/linkedin/types/request/UpdateShareRequestBody.java
@@ -26,6 +26,7 @@ import com.eclipsesource.json.Json;
  * Update share request body
  * @author joanna
  */
+@Deprecated
 public class UpdateShareRequestBody {
   
   @LinkedIn("patch")

--- a/src/main/java/com/echobox/api/linkedin/types/social/actions/CommentsSummary.java
+++ b/src/main/java/com/echobox/api/linkedin/types/social/actions/CommentsSummary.java
@@ -25,6 +25,7 @@ import lombok.Setter;
  * Comments Summary
  * @author Alexandros
  */
+@Deprecated
 public class CommentsSummary {
   
   @Getter

--- a/src/main/java/com/echobox/api/linkedin/types/social/actions/LikeAction.java
+++ b/src/main/java/com/echobox/api/linkedin/types/social/actions/LikeAction.java
@@ -27,6 +27,7 @@ import lombok.Setter;
  * Like Action
  * @author Alexandros
  */
+@Deprecated
 public class LikeAction extends ContainsURN {
   
   @Getter

--- a/src/main/java/com/echobox/api/linkedin/types/social/actions/SocialAction.java
+++ b/src/main/java/com/echobox/api/linkedin/types/social/actions/SocialAction.java
@@ -27,6 +27,7 @@ import lombok.Setter;
  * Social Action Model
  * @author Alexandros
  */
+@Deprecated
 public class SocialAction extends ContainsURN {
   
   @Getter

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/Commentary.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/Commentary.java
@@ -28,6 +28,7 @@ import java.util.List;
  * Commentary
  * @author joanna
  */
+@Deprecated
 public class Commentary {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/Distribution.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/Distribution.java
@@ -28,6 +28,7 @@ import java.util.List;
  * <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#distribution">Distribution</a>
  * @author joanna
  */
+@Deprecated
 public class Distribution {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ExternalDistributionChannelType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ExternalDistributionChannelType.java
@@ -22,6 +22,7 @@ package com.echobox.api.linkedin.types.ugc;
  * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#distribution">External Distribution Channel Type</a>
  * @author joanna
  */
+@Deprecated
 public enum ExternalDistributionChannelType {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/LifeCycleState.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/LifeCycleState.java
@@ -21,6 +21,7 @@ package com.echobox.api.linkedin.types.ugc;
  * The state of the content
  * @author joanna
  */
+@Deprecated
 public enum LifeCycleState {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/Origin.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/Origin.java
@@ -21,6 +21,7 @@ package com.echobox.api.linkedin.types.ugc;
  * Origin
  * @author joanna
  */
+@Deprecated
 public enum Origin {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ResponseContext.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ResponseContext.java
@@ -26,6 +26,7 @@ import lombok.Getter;
  * @see <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#responsecontext">Response Context</a>
  * @author joanna
  */
+@Deprecated
 public class ResponseContext {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ShareContent.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ShareContent.java
@@ -30,6 +30,7 @@ import java.util.List;
  * <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#sharecontent">Share Content</a>
  * @author joanna
  */
+@Deprecated
 public class ShareContent {
   
   @Getter
@@ -86,6 +87,7 @@ public class ShareContent {
      * Categorization info associated with the share.
      * @author joanna
      */
+    @Deprecated
     public static class ShareCategorization {
     
       /**

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ShareMedia.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ShareMedia.java
@@ -30,6 +30,7 @@ import java.util.List;
  * <a href="https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#sharemedia">Share Media</a>
  * @author joanna
  */
+@Deprecated
 public class ShareMedia {
   
   /**
@@ -99,6 +100,7 @@ public class ShareMedia {
   /**
    * Url that overrides the landing page.
    */
+  @Deprecated
   public static class LandingPage {
     /**
      * content entity will be rendered as a CTA with landingPageTitle as the CTA text and
@@ -122,6 +124,7 @@ public class ShareMedia {
    * An overlay associated with a media(video, image etc).
    * @author joanna
    */
+  @Deprecated
   public static class MediaOverlay {
     
     /**
@@ -157,6 +160,7 @@ public class ShareMedia {
   /**
    * The thumbnail saved from the ingestion of this article.
    */
+  @Deprecated
   public static class Thumbnail {
   
     /**

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ShareMediaCategory.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ShareMediaCategory.java
@@ -21,6 +21,7 @@ package com.echobox.api.linkedin.types.ugc;
  * Share media category
  * @author joanna
  */
+@Deprecated
 public enum ShareMediaCategory {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/TargetAudience.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/TargetAudience.java
@@ -34,6 +34,7 @@ import java.util.List;
  * @author joanna
  */
 @EqualsAndHashCode
+@Deprecated
 public class TargetAudience implements Serializable {
   // CPD-OFF
   // Ignore CPD as this will be removed after migration (use VersionedConnection)
@@ -53,6 +54,7 @@ public class TargetAudience implements Serializable {
    * @author joanna
    */
   @EqualsAndHashCode
+  @Deprecated
   public static class TargetAudienceEntity implements Serializable {
   
     private static final long serialVersionUID = -1L;

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/UGCShare.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/UGCShare.java
@@ -33,6 +33,7 @@ import lombok.Setter;
  * @author joanna
  */
 @RequiredArgsConstructor
+@Deprecated
 public class UGCShare extends LinkedInURNIdType {
   
   /**
@@ -182,6 +183,7 @@ public class UGCShare extends LinkedInURNIdType {
    * @author Joanna
    */
   @RequiredArgsConstructor
+  @Deprecated
   public static class Visibility {
     @Getter
     @Setter

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/ViewContext.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/ViewContext.java
@@ -21,6 +21,7 @@ package com.echobox.api.linkedin.types.ugc;
  * The context in which the user generated content is being viewed.
  * @author joanna
  */
+@Deprecated
 public enum ViewContext {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/ugc/Visibility.java
+++ b/src/main/java/com/echobox/api/linkedin/types/ugc/Visibility.java
@@ -21,6 +21,7 @@ package com.echobox.api.linkedin.types.ugc;
  * Visibility enum
  * @author joanna
  */
+@Deprecated
 public enum Visibility {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/urn/LocaleStringNameURN.java
+++ b/src/main/java/com/echobox/api/linkedin/types/urn/LocaleStringNameURN.java
@@ -26,6 +26,7 @@ import lombok.Getter;
  * @author Joanna
  *
  */
+@Deprecated
 public abstract class LocaleStringNameURN extends ContainsURN {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/urn/function/FunctionURN.java
+++ b/src/main/java/com/echobox/api/linkedin/types/urn/function/FunctionURN.java
@@ -29,6 +29,7 @@ import lombok.Getter;
  * @author joanna
  *
  */
+@Deprecated
 public class FunctionURN extends ContainsURN {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/urn/location/CountryGroupURN.java
+++ b/src/main/java/com/echobox/api/linkedin/types/urn/location/CountryGroupURN.java
@@ -27,6 +27,7 @@ import lombok.Getter;
  * @author joanna
  *
  */
+@Deprecated
 public class CountryGroupURN extends LocaleStringNameURN {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/urn/location/CountryURN.java
+++ b/src/main/java/com/echobox/api/linkedin/types/urn/location/CountryURN.java
@@ -28,6 +28,7 @@ import lombok.Getter;
  * @author joanna
  *
  */
+@Deprecated
 public class CountryURN extends LocaleStringNameURN {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/urn/location/DegreeURN.java
+++ b/src/main/java/com/echobox/api/linkedin/types/urn/location/DegreeURN.java
@@ -26,6 +26,7 @@ import com.echobox.api.linkedin.types.urn.function.FunctionURN;
  * @see <a href="https://docs.microsoft.com/en-us/linkedin/shared/references/v2/standardized-data/degrees?context=linkedin/marketing/context">Degree URN</a>
  * @author joanna
  */
+@Deprecated
 public class DegreeURN extends FunctionURN {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/urn/location/FieldOfStudyURN.java
+++ b/src/main/java/com/echobox/api/linkedin/types/urn/location/FieldOfStudyURN.java
@@ -28,6 +28,7 @@ import java.util.List;
  * <a href="https://docs.microsoft.com/en-us/linkedin/shared/references/v2/standardized-data/fields-of-study?context=linkedin/marketing/context">Field of Study URN</a>
  * @author joanna
  */
+@Deprecated
 public class FieldOfStudyURN extends FunctionURN {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/urn/location/PlaceURN.java
+++ b/src/main/java/com/echobox/api/linkedin/types/urn/location/PlaceURN.java
@@ -29,6 +29,7 @@ import lombok.Getter;
  * @author joanna
  *
  */
+@Deprecated
 public class PlaceURN extends LocaleStringNameURN {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/urn/location/RegionURN.java
+++ b/src/main/java/com/echobox/api/linkedin/types/urn/location/RegionURN.java
@@ -30,6 +30,7 @@ import java.util.List;
  * @author joanna
  *
  */
+@Deprecated
 public class RegionURN extends LocaleStringNameURN {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/urn/location/StateURN.java
+++ b/src/main/java/com/echobox/api/linkedin/types/urn/location/StateURN.java
@@ -28,6 +28,7 @@ import lombok.Getter;
  * @author joanna
  *
  */
+@Deprecated
 public class StateURN extends LocaleStringNameURN {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/v1/Address.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/Address.java
@@ -25,6 +25,7 @@ import lombok.Getter;
  * @author Joanna
  *
  */
+@Deprecated
 public class Address {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/v1/CodeAndNameType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/CodeAndNameType.java
@@ -30,6 +30,7 @@ import lombok.RequiredArgsConstructor;
  */
 @NoArgsConstructor
 @RequiredArgsConstructor
+@Deprecated
 public class CodeAndNameType {
   
   @Getter

--- a/src/main/java/com/echobox/api/linkedin/types/v1/CodeType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/CodeType.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.text.WordUtils;
  *
  * @param <T> type
  */
+@Deprecated
 public interface CodeType<T> {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/v1/Company.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/Company.java
@@ -31,6 +31,7 @@ import java.util.List;
  * @author Joanna
  *
  */
+@Deprecated
 public class Company extends LinkedInIdAndNameType {
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/v1/CompanyType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/CompanyType.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 @RequiredArgsConstructor
+@Deprecated
 public enum CompanyType implements CodeType<String> {
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/v1/ContactInfo.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/ContactInfo.java
@@ -25,6 +25,7 @@ import lombok.Getter;
  * @author Joanna
  *
  */
+@Deprecated
 public class ContactInfo {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/v1/EmployeeCountRange.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/EmployeeCountRange.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 @RequiredArgsConstructor
+@Deprecated
 public enum EmployeeCountRange implements CodeType<String> {
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/v1/IndustryCode.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/IndustryCode.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
  * @author Joanna
  *
  */
+@Deprecated
 public enum IndustryCode implements CodeType<Integer> {
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/v1/Location.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/Location.java
@@ -25,6 +25,7 @@ import lombok.Getter;
  * @author Joanna
  *
  */
+@Deprecated
 public class Location {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/v1/Share.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/Share.java
@@ -30,6 +30,7 @@ import lombok.Setter;
  *
  */
 @AllArgsConstructor
+@Deprecated
 public class Share {
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/v1/StatusType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/StatusType.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 @RequiredArgsConstructor
+@Deprecated
 public enum StatusType implements CodeType<String> {
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/v1/StockExchange.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/StockExchange.java
@@ -24,6 +24,7 @@ import lombok.Getter;
  * @author Joanna
  *
  */
+@Deprecated
 public enum StockExchange implements CodeType<Integer> {
 
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/v1/Update.java
+++ b/src/main/java/com/echobox/api/linkedin/types/v1/Update.java
@@ -26,6 +26,7 @@ import lombok.Getter;
  * @author Joanna
  *
  */
+@Deprecated
 public class Update {
   
   @Getter


### PR DESCRIPTION
### Description of Changes
- Mark deprecated classes
- Revert default versioned month (contains breaking changes)
  - Version `202301` does not accept the `viewContext` parameter when retrieving a post and returns a `400` response:
  - `{"message":"Parameter 'viewContext' is invalid","status":400}`
- Fix URL encoding for retrieving a post

### Documentation
N/A

### Risks & Impacts
Low

### Testing

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.