### PR TITLE
SL-4610 Implement functionality to retrieve image details

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedImageConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedImageConnection.java
@@ -22,9 +22,11 @@ import com.echobox.api.linkedin.client.Parameter;
 import com.echobox.api.linkedin.client.VersionedLinkedInClient;
 import com.echobox.api.linkedin.client.WebRequestor;
 import com.echobox.api.linkedin.exception.LinkedInNetworkException;
+import com.echobox.api.linkedin.types.images.ImageDetails;
 import com.echobox.api.linkedin.types.images.InitializeUpload;
 import com.echobox.api.linkedin.types.images.InitializeUploadRequestBody;
 import com.echobox.api.linkedin.types.urn.URN;
+import com.echobox.api.linkedin.util.URLUtils;
 import com.echobox.api.linkedin.util.ValidationUtils;
 
 import java.io.File;
@@ -159,5 +161,16 @@ public class VersionedImageConnection extends VersionedConnection {
     ValidationUtils.validateResponse(response);
     
     return response.getHeaders();
+  }
+  
+  /**
+   * Retrieve the details of an image using the image URN
+   * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api#get-a-single-image">GET a single image</a>
+   * @param imageURN the image URN to retrieve the details of
+   * @return the image details
+   */
+  public ImageDetails retrieveImageDetails(URN imageURN) {
+    return linkedinClient.fetchObject(IMAGES + "/" + URLUtils.urlEncode(imageURN.toString()),
+        ImageDetails.class);
   }
 }

--- a/src/main/java/com/echobox/api/linkedin/types/images/ImageDetails.java
+++ b/src/main/java/com/echobox/api/linkedin/types/images/ImageDetails.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.images;
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import com.echobox.api.linkedin.types.urn.URN;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageDetails {
+  
+  @LinkedIn
+  private URN owner;
+  
+  @LinkedIn
+  private URN id;
+  
+  @LinkedIn
+  private String downloadUrl;
+  
+  @LinkedIn
+  private Long downloadUrlExpiresAt;
+  
+  @LinkedIn
+  private String status;
+}


### PR DESCRIPTION
### Description of Changes
- Add `retrieveImageDetails` method in `VersionedImageConnection` class

### Documentation
https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api#get-a-single-image

### Risks & Impacts
Low

### Testing
Tested manually:
```
VersionedImageConnection connection = new VersionedImageConnection(client);
ImageDetails imageDetails = connection.retrieveImageDetails(new URN("urn:li:image:C4D10AQFEzD9yKMG1Aw"));

Result:
imageDetails = ImageDetails(owner=urn:li:organization:19049739, id=urn:li:image:C4D10AQFEzD9yKMG1Aw, downloadUrl=https://media.licdn.com/dms/image/C4D10AQFEzD9yKMG1Aw/image-shrink_1280/0/1675696947631?e=1676559600&v=beta&t=m0GVzFrNj203QU_bAS0vD1FKuEEvP2Q4cxvgbofxPoM, downloadUrlExpiresAt=1676559600000, status=AVAILABLE)
```

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.