### PR TITLE
SL-4613 Extend post object to contain image details and helper methods

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/types/images/ImageDetails.java
+++ b/src/main/java/com/echobox/api/linkedin/types/images/ImageDetails.java
@@ -28,6 +28,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ImageDetails {
   
+  public ImageDetails(String downloadUrl) {
+    this.downloadUrl = downloadUrl;
+  }
+  
   @LinkedIn
   private URN owner;
   

--- a/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
+++ b/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
@@ -28,6 +28,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -231,6 +232,7 @@ public class Post extends LinkedInURNIdType {
   public List<String> getImageURLs() {
     return images.values().stream()
         .map(ImageDetails::getDownloadUrl)
+        .filter(StringUtils::isNoneBlank)
         .collect(Collectors.toList());
   }
   

--- a/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
+++ b/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -221,22 +222,16 @@ public class Post extends LinkedInURNIdType {
   }
   
   public String getDescription() {
-    Content content = this.getContent();
-    if (content == null) {
-      return null;
-    }
-    
-    if (content.getArticle() == null) {
-      return null;
-    }
-    
-    return content.getArticle().getDescription();
+    return Optional.ofNullable(this.getContent())
+        .map(Content::getArticle)
+        .map(ArticleContent::getDescription)
+        .orElse(null);
   }
   
   public List<String> getImageURLs() {
     return images.values().stream()
         .map(ImageDetails::getDownloadUrl)
-        .filter(StringUtils::isNoneBlank)
+        .filter(StringUtils::isNotBlank)
         .collect(Collectors.toList());
   }
   

--- a/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
+++ b/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
@@ -195,6 +195,10 @@ public class Post extends LinkedInURNIdType {
   @LinkedIn
   private Visibility visibility;
   
+  /**
+   * Mapping of image URN to image details.
+   * The image details will need to be retrieved via a separate API call and populated manually.
+   */
   @Getter
   @Setter
   private Map<URN, ImageDetails> images;

--- a/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
+++ b/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
@@ -19,6 +19,7 @@ package com.echobox.api.linkedin.types.posts;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 import com.echobox.api.linkedin.types.LinkedInURNIdType;
+import com.echobox.api.linkedin.types.images.ImageDetails;
 import com.echobox.api.linkedin.types.urn.URN;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,6 +28,10 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Post
@@ -188,6 +193,46 @@ public class Post extends LinkedInURNIdType {
   @NonNull
   @LinkedIn
   private Visibility visibility;
+  
+  @Getter
+  @Setter
+  private Map<URN, ImageDetails> images;
+
+  public String getTitle() {
+    Content content = this.getContent();
+    if (content == null) {
+      return null;
+    }
+    
+    if (content.getMedia() != null) {
+      return content.getMedia().getTitle();
+    }
+    
+    if (content.getArticle() != null) {
+      return content.getArticle().getTitle();
+    }
+    
+    return null;
+  }
+  
+  public String getDescription() {
+    Content content = this.getContent();
+    if (content == null) {
+      return null;
+    }
+    
+    if (content.getArticle() == null) {
+      return null;
+    }
+    
+    return content.getArticle().getDescription();
+  }
+  
+  public List<String> getImageURLs() {
+    return images.values().stream()
+        .map(ImageDetails::getDownloadUrl)
+        .collect(Collectors.toList());
+  }
   
   /**
    * ContentCallToActionLabel enum


### PR DESCRIPTION
### Description of Changes
- Add images map to `Post` object
- Add helper methods to retrieve `title` and `description`

### Documentation

### Risks & Impacts

### Testing

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.