### PR TITLE
GH-314 Enable fetching video details

### DIFF
--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedVideoConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedVideoConnection.java
@@ -27,6 +27,8 @@ import com.echobox.api.linkedin.types.urn.URN;
 import com.echobox.api.linkedin.types.videos.FinalizeUploadRequest;
 import com.echobox.api.linkedin.types.videos.InitializeUploadRequest;
 import com.echobox.api.linkedin.types.videos.InitializeUploadResponse;
+import com.echobox.api.linkedin.types.videos.VideoDetails;
+import com.echobox.api.linkedin.util.URLUtils;
 import com.echobox.api.linkedin.util.ValidationUtils;
 import org.apache.http.entity.ContentType;
 
@@ -159,5 +161,10 @@ public class VersionedVideoConnection extends VersionedConnection {
       videoInputStream.read(bytes);
       return bytes;
     }
+  }
+
+  public VideoDetails retrieveVideoDetails(URN videoURN) {
+    return linkedinClient.fetchObject(
+        VIDEOS + "/" + URLUtils.urlEncode(videoURN.toString()), VideoDetails.class);
   }
 }

--- a/src/main/java/com/echobox/api/linkedin/types/videos/VideoDetails.java
+++ b/src/main/java/com/echobox/api/linkedin/types/videos/VideoDetails.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.videos;
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import com.echobox.api.linkedin.types.urn.URN;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VideoDetails {
+
+  public VideoDetails(String downloadUrl) {
+    this.downloadUrl = downloadUrl;
+  }
+
+  @LinkedIn
+  private URN owner;
+
+  @LinkedIn
+  private URN id;
+
+  @LinkedIn
+  private String downloadUrl;
+
+  @LinkedIn
+  private Long downloadUrlExpiresAt;
+
+  @LinkedIn
+  private String status;
+
+  @LinkedIn
+  private String thumbnail;
+
+  @LinkedIn
+  private Float aspectRatioWidth;
+
+  @LinkedIn
+  private Float aspectRatioHeight;
+
+  @LinkedIn
+  private Long duration;
+}


### PR DESCRIPTION
### Description of Changes

This pull requests provides a way to get video details from a video URN. A `VideoDetails` class is also added in order to map the response from LinkedIn. Fixes #314

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.