### PR TITLE
SL-5153 Allow thumbnail image upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,3 +173,6 @@ can get data for both organization and organization brand pages.
 
 ## 4.3.1 (Mar 14, 2023)
 * Add a flag to note that we want to upload a thumbnail image along with the video
+
+## 4.4.0 (Mar 16, 2023)
+* Add support to upload thumbnail image to a video

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>4.3.1</version>
+  <version>4.4.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/connection/v2/AssetsConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/v2/AssetsConnection.java
@@ -21,6 +21,7 @@ import com.echobox.api.linkedin.client.BinaryAttachment;
 import com.echobox.api.linkedin.client.LinkedInClient;
 import com.echobox.api.linkedin.client.Parameter;
 import com.echobox.api.linkedin.client.WebRequestor;
+import com.echobox.api.linkedin.connection.versioned.UploadHelper;
 import com.echobox.api.linkedin.exception.LinkedInNetworkException;
 import com.echobox.api.linkedin.types.assets.CheckStatusUpload;
 import com.echobox.api.linkedin.types.assets.CompleteMultiPartUploadBody;
@@ -30,9 +31,7 @@ import com.echobox.api.linkedin.types.urn.URN;
 import com.echobox.api.linkedin.util.ValidationUtils;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
@@ -81,11 +80,8 @@ public class AssetsConnection extends ConnectionBaseV2 {
    */
   public URN uploadImageAsset(RegisterUploadRequestBody registerUploadRequestBody, String filename,
       File file) throws IOException {
-    try (InputStream videoInputStream = new FileInputStream(file)) {
-      byte[] bytes = new byte[(int) file.length()];
-      videoInputStream.read(bytes);
-      return uploadImageAsset(registerUploadRequestBody, filename, bytes);
-    }
+    byte[] bytes = UploadHelper.convertFileToBytes(file);
+    return uploadImageAsset(registerUploadRequestBody, filename, bytes);
   }
   
   /**
@@ -141,11 +137,8 @@ public class AssetsConnection extends ConnectionBaseV2 {
    */
   public static Map<String, String> uploadAsset(WebRequestor webRequestor, URL uploadURL,
       Map<String, String> headers, String filename, File file) throws IOException {
-    try (InputStream videoInputStream = new FileInputStream(file)) {
-      byte[] bytes = new byte[(int) file.length()];
-      videoInputStream.read(bytes);
-      return uploadAsset(webRequestor, uploadURL, headers, filename, bytes);
-    }
+    byte[] bytes = UploadHelper.convertFileToBytes(file);
+    return uploadAsset(webRequestor, uploadURL, headers, filename, bytes);
   }
   
   // CPD-OFF

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/UploadHelper.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/UploadHelper.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.connection.versioned;
+
+import com.echobox.api.linkedin.client.BinaryAttachment;
+import com.echobox.api.linkedin.client.WebRequestor;
+import com.echobox.api.linkedin.exception.LinkedInNetworkException;
+import com.echobox.api.linkedin.exception.LinkedInResponseException;
+import com.echobox.api.linkedin.util.ValidationUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.Map;
+
+/**
+ * Helper class for uploading files to LinkedIn
+ * @author Rado S
+ */
+public class UploadHelper {
+  
+  /**
+   * Upload the image bytes, this should be used to upload each image chunk
+   * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api#uploading-an-image">Upload the Image</a>
+   * @param webRequestor the web requestor - Note that it must not have any existing authorization
+   * tokens
+   * @param uploadURL the uploadUrl from the initialize upload response
+   * @param headers the headers from the initialize upload response
+   * @param filename the file name of the file to be uploaded
+   * @param bytes the bytes to upload
+   * @return the map of headers from the request
+   */
+  public static Map<String, String> uploadImageBytes(WebRequestor webRequestor, URL uploadURL,
+      Map<String, String> headers, String filename, byte[] bytes) {
+    WebRequestor.Response response;
+    try {
+      response = webRequestor.executePut(uploadURL.toString(), null, null, headers,
+          BinaryAttachment.with(filename, bytes));
+    } catch (Exception ex) {
+      throw new LinkedInNetworkException("LinkedIn request failed to upload the image", ex);
+    }
+    
+    ValidationUtils.validateResponse(response);
+    
+    return response.getHeaders();
+  }
+  
+  public static byte[] convertFileToBytes(File file) throws IOException {
+    try (InputStream videoInputStream = Files.newInputStream(file.toPath())) {
+      byte[] bytes = new byte[(int) file.length()];
+      videoInputStream.read(bytes);
+      return bytes;
+    }
+  }
+  
+  public static byte[] convertURLToBytes(URL url) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (InputStream inputStream = url.openStream()) {
+      
+      int byteChunk;
+      
+      while ((byteChunk = inputStream.read()) != -1) {
+        baos.write(byteChunk);
+      }
+    } catch (IOException e) {
+      throw new IOException(
+          String.format("Failed while reading bytes from %s: %s", url.toExternalForm(),
+              e.getMessage()));
+    }
+    
+    return baos.toByteArray();
+  }
+  
+  public static URL extractUploadURL(String url) {
+    try {
+      return new URL(url);
+    } catch (MalformedURLException e) {
+      throw new LinkedInResponseException("Invalid upload url returned from LinkedIn.", e);
+    }
+  }
+}

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedImageConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedImageConnection.java
@@ -17,17 +17,14 @@
 
 package com.echobox.api.linkedin.connection.versioned;
 
-import com.echobox.api.linkedin.client.BinaryAttachment;
 import com.echobox.api.linkedin.client.Parameter;
 import com.echobox.api.linkedin.client.VersionedLinkedInClient;
 import com.echobox.api.linkedin.client.WebRequestor;
-import com.echobox.api.linkedin.exception.LinkedInNetworkException;
 import com.echobox.api.linkedin.types.images.ImageDetails;
 import com.echobox.api.linkedin.types.images.InitializeUpload;
 import com.echobox.api.linkedin.types.images.InitializeUploadRequestBody;
 import com.echobox.api.linkedin.types.urn.URN;
 import com.echobox.api.linkedin.util.URLUtils;
-import com.echobox.api.linkedin.util.ValidationUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -74,9 +71,9 @@ public class VersionedImageConnection extends VersionedConnection {
    */
   public URN uploadImage(InitializeUploadRequestBody initializeUploadRequestBody,
       String filename, File file) throws IOException {
-    try (InputStream videoInputStream = Files.newInputStream(file.toPath())) {
+    try (InputStream imageInputStream = Files.newInputStream(file.toPath())) {
       byte[] bytes = new byte[(int) file.length()];
-      videoInputStream.read(bytes);
+      imageInputStream.read(bytes);
       InitializeUpload initializeUpload = uploadImage(initializeUploadRequestBody, filename, bytes);
       return initializeUpload.getValue().getImage();
     }
@@ -97,7 +94,7 @@ public class VersionedImageConnection extends VersionedConnection {
     InitializeUpload initializeUploadResponse = initializeUpload(initializeUploadRequestBody);
     
     // Upload the image
-    uploadImageBytes(linkedinClient.getWebRequestor(),
+    UploadHelper.uploadImageBytes(linkedinClient.getWebRequestor(),
         new URL(initializeUploadResponse.getValue().getUploadUrl()),
         new HashMap<>(), filename, bytes);
     
@@ -130,37 +127,8 @@ public class VersionedImageConnection extends VersionedConnection {
    */
   public Map<String, String> uploadImageFile(WebRequestor webRequestor, URL uploadURL,
       Map<String, String> headers, String filename, File file) throws IOException {
-    try (InputStream inputStream = Files.newInputStream(file.toPath())) {
-      byte[] bytes = new byte[(int) file.length()];
-      inputStream.read(bytes);
-      return uploadImageBytes(webRequestor, uploadURL, headers, filename, bytes);
-    }
-  }
-  
-  /**
-   * Upload the image bytes, this should be used to upload each image chunk
-   * @see <a href="https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api#uploading-an-image">Upload the Image</a>
-   * @param webRequestor the web requestor - Note that it must not have any existing authorization
-   * tokens
-   * @param uploadURL the uploadUrl from the initialize upload response
-   * @param headers the headers from the initialize upload response
-   * @param filename the file name of the file to be uploaded
-   * @param bytes the bytes to upload
-   * @return the map of headers from the request
-   */
-  public Map<String, String> uploadImageBytes(WebRequestor webRequestor, URL uploadURL,
-      Map<String, String> headers, String filename, byte[] bytes) {
-    WebRequestor.Response response;
-    try {
-      response = webRequestor.executePut(uploadURL.toString(), null, null, headers,
-          BinaryAttachment.with(filename, bytes));
-    } catch (Exception ex) {
-      throw new LinkedInNetworkException("LinkedIn request failed to upload the image", ex);
-    }
-  
-    ValidationUtils.validateResponse(response);
-    
-    return response.getHeaders();
+    byte[] bytes = UploadHelper.convertFileToBytes(file);
+    return UploadHelper.uploadImageBytes(webRequestor, uploadURL, headers, filename, bytes);
   }
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedVideoConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedVideoConnection.java
@@ -22,19 +22,16 @@ import com.echobox.api.linkedin.client.DefaultVersionedLinkedInClient;
 import com.echobox.api.linkedin.client.Parameter;
 import com.echobox.api.linkedin.client.VersionedLinkedInClient;
 import com.echobox.api.linkedin.client.WebRequestor;
-import com.echobox.api.linkedin.exception.LinkedInResponseException;
 import com.echobox.api.linkedin.types.urn.URN;
 import com.echobox.api.linkedin.types.videos.FinalizeUploadRequest;
 import com.echobox.api.linkedin.types.videos.InitializeUploadRequest;
 import com.echobox.api.linkedin.types.videos.InitializeUploadResponse;
 import com.echobox.api.linkedin.util.ValidationUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.entity.ContentType;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -76,29 +73,31 @@ public class VersionedVideoConnection extends VersionedConnection {
     super(linkedinClient);
   }
   
-  public URN uploadVideoFromURL(InitializeUploadRequest initializeUploadRequest, String videoURL)
-      throws IOException {
+  public URN uploadVideoFromURL(InitializeUploadRequest initializeUploadRequest, String videoURL,
+      String thumbnailImageURL) throws IOException {
   
-    URL url = new URL(videoURL);
-    byte[] fileBytes = convertURLToBytes(url);
+    URL url = UploadHelper.extractUploadURL(videoURL);
+    byte[] fileBytes = UploadHelper.convertURLToBytes(url);
     long videoFileSizeBytes = fileBytes.length;
   
-    return getVideoURN(videoFileSizeBytes, initializeUploadRequest, videoURL, fileBytes);
+    return getVideoURN(videoFileSizeBytes, initializeUploadRequest, videoURL, fileBytes,
+        thumbnailImageURL);
   }
   
-  public URN uploadVideoFromFile(InitializeUploadRequest initializeUploadRequest, String filePath)
-      throws IOException {
+  public URN uploadVideoFromFile(InitializeUploadRequest initializeUploadRequest, String filePath,
+      String thumbnailImageURL) throws IOException {
   
     File file = new File(filePath);
     Path videoFilePath = Paths.get(filePath);
-    byte[] fileBytes = convertFileToBytes(file);
+    byte[] fileBytes = UploadHelper.convertFileToBytes(file);
     long videoFileSizeBytes = Files.size(videoFilePath);
     
-    return getVideoURN(videoFileSizeBytes, initializeUploadRequest, filePath, fileBytes);
+    return getVideoURN(videoFileSizeBytes, initializeUploadRequest, filePath,
+        fileBytes, thumbnailImageURL);
   }
   
   private URN getVideoURN(long videoFileSizeBytes, InitializeUploadRequest initializeUploadRequest,
-      String videoLocation, byte[] fileBytes) throws IOException {
+      String videoLocation, byte[] fileBytes, String thumbnailImageURL) throws IOException {
   
     initializeUploadRequest.getInitializeUploadRequest().setFileSizeBytes(videoFileSizeBytes);
     
@@ -110,6 +109,8 @@ public class VersionedVideoConnection extends VersionedConnection {
       String etag = uploadVideoFileChunk(videoLocation, fileBytes, instruction);
       uploadedPartIds.add(etag);
     }
+  
+    uploadThumbnailImage(thumbnailImageURL, initializeUploadResponse);
   
     FinalizeUploadRequest finalizeUploadRequest =
         new FinalizeUploadRequest(value.getVideo(), value.getUploadToken(), uploadedPartIds);
@@ -140,7 +141,7 @@ public class VersionedVideoConnection extends VersionedConnection {
     BinaryAttachment attachment = BinaryAttachment.with(filePath, chunkBytes,
         ContentType.APPLICATION_OCTET_STREAM.toString());
     
-    URL url = extractUploadURL(instruction.getUploadUrl());
+    URL url = UploadHelper.extractUploadURL(instruction.getUploadUrl());
     WebRequestor.Response response =
         webRequestor.executePut(url.toString(), null, null, requestHeaders, attachment);
     Map<String, String> responseHeaders = response.getHeaders();
@@ -149,42 +150,22 @@ public class VersionedVideoConnection extends VersionedConnection {
     return responseHeaders.get(HEADER_ETAG);
   }
   
-  private URL extractUploadURL(String url) {
-    try {
-      return new URL(url);
-    } catch (MalformedURLException e) {
-      throw new LinkedInResponseException("Invalid upload url returned from LinkedIn.", e);
-    }
-  }
-  
   public void finalizeUpload(FinalizeUploadRequest finalizeUploadRequest) {
     linkedinClient.publish(VIDEOS, finalizeUploadRequest,
         Parameter.with(ACTION_KEY, FINALIZE_UPLOAD));
   }
   
-  private byte[] convertURLToBytes(URL videoURL) throws IOException {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    try (InputStream inputStream = videoURL.openStream()) {
-
-      int byteChunk;
-    
-      while ((byteChunk = inputStream.read()) != -1) {
-        baos.write(byteChunk);
+  private void uploadThumbnailImage(String thumbnailImageURL, InitializeUploadResponse
+      initializeUploadResponse) throws IOException {
+    if (StringUtils.isNotEmpty(thumbnailImageURL)) {
+      byte[] bytes =
+          UploadHelper.convertURLToBytes(UploadHelper.extractUploadURL(thumbnailImageURL));
+  
+      String thumbnailUploadUrl = initializeUploadResponse.getThumbnailUploadUrl();
+      if (StringUtils.isNotEmpty(thumbnailUploadUrl)) {
+        UploadHelper.uploadImageBytes(linkedinClient.getWebRequestor(), new URL(thumbnailUploadUrl),
+            new HashMap<>(), thumbnailImageURL, bytes);
       }
-    } catch (IOException e) {
-      throw new IOException(
-          String.format("Failed while reading bytes from %s: %s", videoURL.toExternalForm(),
-              e.getMessage()));
-    }
-  
-    return baos.toByteArray();
-  }
-  
-  private byte[] convertFileToBytes(File file) throws IOException {
-    try (InputStream videoInputStream = Files.newInputStream(file.toPath())) {
-      byte[] bytes = new byte[(int) file.length()];
-      videoInputStream.read(bytes);
-      return bytes;
     }
   }
 }

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedVideoConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedVideoConnection.java
@@ -155,17 +155,21 @@ public class VersionedVideoConnection extends VersionedConnection {
         Parameter.with(ACTION_KEY, FINALIZE_UPLOAD));
   }
   
-  private void uploadThumbnailImage(String thumbnailImageURL, InitializeUploadResponse
-      initializeUploadResponse) throws IOException {
+  private Map<String, String> uploadThumbnailImage(String thumbnailImageURL,
+      InitializeUploadResponse initializeUploadResponse) throws IOException {
+    
+    Map<String, String> responseHeaders = new HashMap<>();
+    
     if (StringUtils.isNotEmpty(thumbnailImageURL)) {
       byte[] bytes =
           UploadHelper.convertURLToBytes(UploadHelper.extractUploadURL(thumbnailImageURL));
-  
       String thumbnailUploadUrl = initializeUploadResponse.getThumbnailUploadUrl();
       if (StringUtils.isNotEmpty(thumbnailUploadUrl)) {
-        UploadHelper.uploadImageBytes(linkedinClient.getWebRequestor(), new URL(thumbnailUploadUrl),
-            new HashMap<>(), thumbnailImageURL, bytes);
+        responseHeaders = UploadHelper.uploadImageBytes(linkedinClient.getWebRequestor(),
+            new URL(thumbnailUploadUrl), new HashMap<>(), thumbnailImageURL, bytes);
       }
     }
+    
+    return responseHeaders;
   }
 }

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedVideoConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedVideoConnection.java
@@ -110,7 +110,7 @@ public class VersionedVideoConnection extends VersionedConnection {
       uploadedPartIds.add(etag);
     }
   
-    uploadThumbnailImage(thumbnailImageURL, initializeUploadResponse);
+    uploadThumbnailImage(thumbnailImageURL, value);
   
     FinalizeUploadRequest finalizeUploadRequest =
         new FinalizeUploadRequest(value.getVideo(), value.getUploadToken(), uploadedPartIds);
@@ -156,14 +156,14 @@ public class VersionedVideoConnection extends VersionedConnection {
   }
   
   private Map<String, String> uploadThumbnailImage(String thumbnailImageURL,
-      InitializeUploadResponse initializeUploadResponse) throws IOException {
+      InitializeUploadResponse.Value initializeUploadResponseValue) throws IOException {
     
     Map<String, String> responseHeaders = new HashMap<>();
     
     if (StringUtils.isNotEmpty(thumbnailImageURL)) {
       byte[] bytes =
           UploadHelper.convertURLToBytes(UploadHelper.extractUploadURL(thumbnailImageURL));
-      String thumbnailUploadUrl = initializeUploadResponse.getThumbnailUploadUrl();
+      String thumbnailUploadUrl = initializeUploadResponseValue.getThumbnailUploadUrl();
       if (StringUtils.isNotEmpty(thumbnailUploadUrl)) {
         responseHeaders = UploadHelper.uploadImageBytes(linkedinClient.getWebRequestor(),
             new URL(thumbnailUploadUrl), new HashMap<>(), thumbnailImageURL, bytes);

--- a/src/main/java/com/echobox/api/linkedin/types/videos/InitializeUploadResponse.java
+++ b/src/main/java/com/echobox/api/linkedin/types/videos/InitializeUploadResponse.java
@@ -35,6 +35,10 @@ public class InitializeUploadResponse {
   @LinkedIn
   private Value value;
   
+  @Getter
+  @LinkedIn
+  private String thumbnailUploadUrl;
+  
   /**
    * Value object
    * @author sergio

--- a/src/main/java/com/echobox/api/linkedin/types/videos/InitializeUploadResponse.java
+++ b/src/main/java/com/echobox/api/linkedin/types/videos/InitializeUploadResponse.java
@@ -35,10 +35,6 @@ public class InitializeUploadResponse {
   @LinkedIn
   private Value value;
   
-  @Getter
-  @LinkedIn
-  private String thumbnailUploadUrl;
-  
   /**
    * Value object
    * @author sergio
@@ -73,6 +69,14 @@ public class InitializeUploadResponse {
     @Getter
     @LinkedIn
     private List<UploadInstruction> uploadInstructions;
+  
+    /**
+     * URL used for uploading thumbnail image for the video. This value will be present only if
+     * initializeUploadRequest.uploadThumbnail is true.
+     */
+    @Getter
+    @LinkedIn
+    private String thumbnailUploadUrl;
   }
   
   /**


### PR DESCRIPTION
### Description of Changes

* Added `thumbnailUploadUrl` field to `InitializeUploadResponse` so we can use it to upload the thumbnail image for a video.
* Created UploadHelper class containing tools for converting files to bytes and uploading files to LinkedIn
* Refactoring

### Documentation
N/A

### Risks & Impacts
N/A

### Testing
* Tested by running the app locally and successfully shared a video to Linked with a thumbnail image

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.