### PR TITLE
SL-5141 Add more data to debug log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,3 +176,6 @@ can get data for both organization and organization brand pages.
 
 ## 4.4.0 (Mar 16, 2023)
 * Add support to upload thumbnail image to a video
+
+## 4.4.1 (Mar 17, 2023)
+* Add more detail to debug logs

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>4.4.0</version>
+  <version>4.4.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -227,6 +227,7 @@ public class DefaultWebRequestor implements WebRequestor {
     return executePost(url, parameters, jsonBody, null, new BinaryAttachment[0]);
   }
 
+  // CPD-OFF
   @Override
   public Response executePost(String url, String parameters, String jsonBody,
       Map<String, String> headers,
@@ -337,7 +338,7 @@ public class DefaultWebRequestor implements WebRequestor {
           // Ensure the response headers are also set to JSON
           request.setResponseHeaders(new HttpHeaders().set(FORMAT_HEADER, "json"));
         } else {
-          // Plain old POST request
+          // Plain old PUT request
           request = requestFactory.buildPutRequest(genericUrl, null);
         }
       }
@@ -366,6 +367,7 @@ public class DefaultWebRequestor implements WebRequestor {
       }
     }
   }
+  // CPD-ON
   
   private Response getResponse(HttpRequest request) throws IOException {
     HttpResponse httpResponse = request.execute();

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -234,14 +234,6 @@ public class DefaultWebRequestor implements WebRequestor {
       BinaryAttachment... binaryAttachments)
       throws IOException {
     
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Executing a POST to " + url + " with parameters "
-          + (binaryAttachments.length > 0 ? "" : "(sent in request body): ")
-          + URLUtils.urlDecode(parameters)
-          + (binaryAttachments.length > 0 ? " and " + binaryAttachments.length
-              + " binary attachment[s]." : ""));
-    }
-
     if (binaryAttachments == null) {
       binaryAttachments = new BinaryAttachment[0];
     }
@@ -294,6 +286,13 @@ public class DefaultWebRequestor implements WebRequestor {
       customizeConnection(request);
   
       addHeadersToRequest(request, httpHeaders, headers);
+  
+      if (LOGGER.isDebugEnabled()) {
+        String body = StringUtils.isEmpty(jsonBody) ? "no payload"
+            : format("payload: %s", jsonBody);
+        LOGGER.debug(format("Executing a POST to %s with %s and headers: %s.",
+            request.getUrl().toString(), body, request.getHeaders().toString()));
+      }
 
       return getResponse(request);
     } catch (HttpResponseException ex) {
@@ -311,14 +310,6 @@ public class DefaultWebRequestor implements WebRequestor {
   public Response executePut(String url, String parameters, String jsonBody,
       Map<String, String> headers, BinaryAttachment binaryAttachment)
       throws IOException {
-  
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Executing a PUT to " + url + " with parameters "
-          + (binaryAttachment != null ? "" : "(sent in request body): ")
-          + URLUtils.urlDecode(parameters)
-          + (binaryAttachment != null ? " and " + binaryAttachment
-          + " binary attachment." : ""));
-    }
   
     try {
       GenericUrl genericUrl = getGenericURL(url, parameters);
@@ -360,6 +351,13 @@ public class DefaultWebRequestor implements WebRequestor {
   
       addHeadersToRequest(request, httpHeaders, headers);
     
+      if (LOGGER.isDebugEnabled()) {
+        String body = StringUtils.isEmpty(jsonBody) ? "no payload"
+            : format("payload: %s", jsonBody);
+        LOGGER.debug(format("Executing a PUT to %s with %s and headers: %s.",
+            request.getUrl().toString(), body, request.getHeaders().toString()));
+      }
+  
       return getResponse(request);
     } catch (HttpResponseException ex) {
       return handleException(ex);
@@ -514,7 +512,8 @@ public class DefaultWebRequestor implements WebRequestor {
   private Response execute(String url, HttpMethod httpMethod, Map<String, String> headers)
       throws IOException {
     if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug(format("Making a %s request to %s", httpMethod.name(), url));
+      LOGGER.debug(format("Making a %s request to %s with headers %s", httpMethod.name(), url,
+          headers));
     }
 
     HttpResponse httpResponse = null;

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -20,7 +20,6 @@ package com.echobox.api.linkedin.client;
 import static java.lang.String.format;
 
 import com.echobox.api.linkedin.util.JsonUtils;
-import com.echobox.api.linkedin.util.URLUtils;
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;

--- a/src/main/java/com/echobox/api/linkedin/client/WebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/WebRequestor.java
@@ -99,7 +99,7 @@ public interface WebRequestor {
     public String toString() {
       String responseBody = StringUtils.isBlank(getBody()) ? "an empty response body" :
           format("response body: %s", getBody());
-      return format("HTTP status code %d and %s and headers %s.", getStatusCode(), responseBody,
+      return format("HTTP status code %d with %s and headers %s.", getStatusCode(), responseBody,
           getHeaders());
     }
   }

--- a/src/main/java/com/echobox/api/linkedin/client/WebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/WebRequestor.java
@@ -97,10 +97,10 @@ public interface WebRequestor {
      */
     @Override
     public String toString() {
-      if (StringUtils.isBlank(getBody())) {
-        return format("HTTP status code %d and an empty response body.", getStatusCode());
-      }
-      return format("HTTP status code %d and response body: %s", getStatusCode(), getBody());
+      String responseBody = StringUtils.isBlank(getBody()) ? "an empty response body" :
+          format("response body: %s", getBody());
+      return format("HTTP status code %d and %s and headers %s.", getStatusCode(), responseBody,
+          getHeaders());
     }
   }
 


### PR DESCRIPTION
### Description of Changes
- Add more data to debug logs

### Documentation

### Risks & Impacts

### Testing
Have run locally resulting in the following output:
```
17/03 15:55:27.292 [00001-main] DEBUG c.e.a.l.client.DefaultWebRequestor - Executing a POST to https://api.linkedin.com/rest/images?action=initializeUpload with  payload: {"initializeUploadRequest":{"owner":"urn:li:organization:19049739"}} and headers: GenericData{classInfo=[accept, accept-encoding, age, authorization, cache-control, content-encoding, content-length, content-md5, content-range, content-type, cookie, date, etag, expires, if-match, if-modified-since, if-none-match, if-range, if-unmodified-since, last-modified, location, mime-version, range, retry-after, user-agent, warning, www-authenticate], {accept-encoding=[gzip], linkedin-version=202211}}.
17/03 15:55:28.232 [00001-main] DEBUG c.e.a.l.client.DefaultWebRequestor - LinkedIn responded with HTTP status code 200 and response body: {"value":{"uploadUrlExpiresAt":1679147728139,"uploadUrl":"https://www.linkedin.com/dms-uploads/C4D10AQHP1ldLeQ1cJg/uploaded-image/0?ca=vector_ads&cn=uploads&sync=0&v=beta&ut=3H-sFzg4jz0qI1","image":"urn:li:image:C4D10AQHP1ldLeQ1cJg"}} and headers {date=Fri, 17 Mar 2023 13:55:28 GMT, content-length=234, set-cookie=[lidc="b=VB87:s=V:r=V:a=V:p=V:g=2966:u=475:x=1:i=1679061328:t=1679146793:v=2:sig=AQHiuGuaLuc9qVQMwfUDMusgEQLdd6if", bcookie="v=2&5c351c02-f29d-4245-8b4c-114ddbdbbc0c"; domain=.linkedin.com; Path=/; Secure; Expires=Sat, 16-Mar-2024 13:55:28 GMT; SameSite=None], x-li-uuid=AAX3GO4Cbw/X0Vluoh2AlA==, x-li-fabric=prod-lva1, x-li-route-key="b=VB87:s=V:r=V:a=V:p=V:g=2966:u=475:x=1:i=1679061328:t=1679146793:v=2:sig=AQHiuGuaLuc9qVQMwfUDMusgEQLdd6if", x-restli-protocol-version=1.0.0, x-li-proto=http/1.1, x-li-pop=prod-lva1-x, content-type=application/json, connection=keep-alive}.
17/03 15:55:28.235 [00001-main] DEBUG c.e.a.l.client.DefaultWebRequestor - Executing a PUT to https://www.linkedin.com/dms-uploads/C4D10AQHP1ldLeQ1cJg/uploaded-image/0?ca=vector_ads&cn=uploads&sync=0&v=beta&ut=3H-sFzg4jz0qI1 with parameters null and [filename=/home/sergio/Pictures/image2.jpg] binary attachment.
17/03 15:55:28.944 [00001-main] DEBUG c.e.a.l.client.DefaultWebRequestor - LinkedIn responded with HTTP status code 201 and an empty response body and headers {date=Fri, 17 Mar 2023 13:55:28 GMT, content-length=0, expires=Thu, 01 Jan 1970 00:00:00 GMT, x-li-fabric=prod-ltx1, x-li-proto=http/1.1, x-frame-options=sameorigin, expect-ct=max-age=86400, report-uri="https://www.linkedin.com/platform-telemetry/ct", pragma=no-cache, strict-transport-security=max-age=31536000, access-control-allow-origin=https://www.linkedin.com, set-cookie=[lidc="b=TGST06:s=T:r=T:a=T:p=T:g=2607:u=1:x=1:i=1679061328:t=1679147728:v=2:sig=AQEHAa4sj0TaETF7SYqd4tbZqeDe2tzL"; Expires=Sat, 18 Mar 2023 13:55:28 GMT; domain=.linkedin.com; Path=/; SameSite=None; Secure, bscookie="v=1&202303171355288c2917a5-0c90-4a88-8d33-c23f12a1c6b6AQH-m4lxETJ8H0T9eVWyZC_uT24tXytV"; domain=.www.linkedin.com; Path=/; Secure; Expires=Sat, 16-Mar-2024 13:55:28 GMT; HttpOnly; SameSite=None, bcookie="v=2&fa799523-776e-4007-86af-b45c81c51ff7"; domain=.linkedin.com; Path=/; Secure; Expires=Sat, 16-Mar-2024 13:55:28 GMT; SameSite=None, lang=v=2&lang=en-us; SameSite=None; Path=/; Domain=linkedin.com; Secure], x-li-uuid=AAX3GO4KMhGVL8UdvgIt1A==, content-security-policy=default-src *; connect-src 'self' *.licdn.com *.linkedin.com wss://*.linkedin.com dpm.demdex.net/id lnkd.demdex.net blob: accounts.google.com/gsi/ linkedin.sc.omtrdc.net/b/ss/ *.qualtrics.com *.adyen.com *.microsoft.com; img-src data: blob: *; font-src data: *; style-src 'unsafe-inline' 'self' static-src.linkedin.com *.licdn.com; script-src 'unsafe-inline' 'unsafe-eval' 'self' spdy.linkedin.com static-src.linkedin.com *.ads.linkedin.com *.licdn.com static.chartbeat.com bcvipva02.rightnowtech.com www.bizographics.com sjs.bizographics.com js.bizographics.com d.la4-c1-was.salesforceliveagent.com platform.linkedin.com platform-akam.linkedin.com platform-ecst.linkedin.com platform-azur.linkedin.com; object-src 'none'; media-src blob: *; worker-src 'self' blob: static.licdn.com static-exp1.licdn.com static-exp2.licdn.com static-exp3.licdn.com; frame-src blob: lnkd-communities: voyager: *; frame-ancestors 'self' *.linkedin.com teams.microsoft.com client.learningapp.microsoft.com; report-uri /security/csp?e=p&f=t, x-content-type-options=nosniff, x-msedge-ref=Ref A: 813D4C7F6ADF4FACA27F4FD4B6E8A983 Ref B: CPT02EDGE0607 Ref C: 2023-03-17T13:55:28Z, x-li-pop=afd-prod-ltx1-x, x-ambry-creation-time=Fri Mar 17 13:55:28 UTC 2023, x-cache=CONFIG_NOCACHE, cache-control=no-cache, no-store}.
17/03 15:55:28.952 [00001-main] DEBUG c.e.a.l.client.DefaultWebRequestor - Executing a POST to https://api.linkedin.com/rest/posts with  payload: {"author":"urn:li:organization:19049739","commentary":"Im a picture","content":{"media":{"id":"urn:li:image:C4D10AQHP1ldLeQ1cJg","title":"Image title"}},"distribution":{"feedDistribution":"MAIN_FEED"},"lifecycleState":"PUBLISHED","visibility":"PUBLIC"} and headers: GenericData{classInfo=[accept, accept-encoding, age, authorization, cache-control, content-encoding, content-length, content-md5, content-range, content-type, cookie, date, etag, expires, if-match, if-modified-since, if-none-match, if-range, if-unmodified-since, last-modified, location, mime-version, range, retry-after, user-agent, warning, www-authenticate], {accept-encoding=[gzip], linkedin-version=202211}}.
17/03 15:55:29.464 [00001-main] DEBUG c.e.a.l.client.DefaultWebRequestor - LinkedIn responded with HTTP status code 201 and an empty response body and headers {date=Fri, 17 Mar 2023 13:55:29 GMT, content-length=0, set-cookie=[lidc="b=VB87:s=V:r=V:a=V:p=V:g=2966:u=475:x=1:i=1679061329:t=1679146793:v=2:sig=AQG-g_xH8dkmptfhRTzP44MnOUQGkyEF", bcookie="v=2&a0b09755-377b-4402-89f3-428fc0ab2e29"; domain=.linkedin.com; Path=/; Secure; Expires=Sat, 16-Mar-2024 13:55:29 GMT; SameSite=None], x-li-uuid=AAX3GO4TmTUOcHLJEm3vDA==, x-li-fabric=prod-lva1, x-li-route-key="b=VB87:s=V:r=V:a=V:p=V:g=2966:u=475:x=1:i=1679061329:t=1679146793:v=2:sig=AQG-g_xH8dkmptfhRTzP44MnOUQGkyEF", x-restli-protocol-version=1.0.0, x-li-proto=http/1.1, x-li-pop=prod-lva1-x, location=/posts/urn%3Ali%3Ashare%3A7042493649300897794, connection=keep-alive, x-linkedin-id=urn:li:share:7042493649300897794}.
17/03 15:55:29.468 [00001-main] DEBUG c.e.a.l.client.DefaultWebRequestor - Making a GET request to https://api.linkedin.com/rest/posts/urn%3Ali%3Ashare%3A7041760562417971200?viewContext=READER with headers {Linkedin-Version=202211}
17/03 15:55:29.812 [00001-main] DEBUG c.e.a.l.client.DefaultWebRequestor - LinkedIn responded with HTTP status code 200 and response body: {"isReshareDisabledByAuthor":false,"createdAt":1678886547768,"lifecycleState":"PUBLISHED","lastModifiedAt":1678886547952,"visibility":"PUBLIC","publishedAt":1678886547768,"author":"urn:li:organization:19049739","id":"urn:li:share:7041760562417971200","distribution":{"feedDistribution":"MAIN_FEED","thirdPartyDistributionChannels":[]},"content":{"article":{"title":"Here's a Look Back at the 2003 NBA All-Star Game in Atlanta | SLAM","thumbnail":"urn:li:image:C4D10AQHtjDWeHyfT9A","source":"https://www.slamonline.com/the-magazine/look-back-2003-nba-all-star-game-atlanta/?utm_medium=Social&utm_source=LinkedIn#Echobox=1678886545"}},"commentary":"As the the NBA gets ready to host the 72nd Annual All-Star Game in Salt Lake City, here's a look back at the All-Star game in 2003.","lifecycleStateInfo":{"isEditedByAuthor":false}} and headers {date=Fri, 17 Mar 2023 13:55:29 GMT, content-length=828, set-cookie=[lidc="b=VB87:s=V:r=V:a=V:p=V:g=2966:u=475:x=1:i=1679061329:t=1679146793:v=2:sig=AQG-g_xH8dkmptfhRTzP44MnOUQGkyEF", bcookie="v=2&aed1362f-966f-4a99-8b4a-a0dbe595eb11"; domain=.linkedin.com; Path=/; Secure; Expires=Sat, 16-Mar-2024 13:55:29 GMT; SameSite=None], x-li-uuid=AAX3GO4bb13TvA4x2f5lDQ==, x-li-fabric=prod-lva1, x-li-route-key="b=VB87:s=V:r=V:a=V:p=V:g=2966:u=475:x=1:i=1679061329:t=1679146793:v=2:sig=AQG-g_xH8dkmptfhRTzP44MnOUQGkyEF", x-restli-protocol-version=1.0.0, x-li-proto=http/1.1, x-li-pop=prod-lva1-x, content-type=application/json, connection=keep-alive}.

```
## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.