### PR TITLE
SL-5263 Add videos to the Post class in LinkedIn SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,3 +176,7 @@ can get data for both organization and organization brand pages.
 
 ## 4.4.0 (Mar 16, 2023)
 * Add support to upload thumbnail image to a video
+
+## 4.4.1 (Mar 20, 2023)
+* Add support to retrieve video details from LinkedIn
+* Extend `Post` object to include video details mapping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,9 +177,7 @@ can get data for both organization and organization brand pages.
 ## 4.4.0 (Mar 16, 2023)
 * Add support to upload thumbnail image to a video
 
-## 4.4.1 (Mar 17, 2023)
+## 4.4.1 (Mar 20, 2023)
 * Add more detail to debug logs
-
-## 4.4.2 (Mar 20, 2023)
 * Add support to retrieve video details from LinkedIn
 * Extend `Post` object to include video details mapping

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>4.4.2</version>
+  <version>4.4.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>4.4.0</version>
+  <version>4.4.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
+++ b/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
@@ -31,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -238,17 +239,25 @@ public class Post extends LinkedInURNIdType {
   }
   
   public List<String> getImageURLs() {
-    return images.values().stream()
-        .map(ImageDetails::getDownloadUrl)
-        .filter(StringUtils::isNotBlank)
-        .collect(Collectors.toList());
+    if (images != null) {
+      return images.values().stream()
+          .map(ImageDetails::getDownloadUrl)
+          .filter(StringUtils::isNotBlank)
+          .collect(Collectors.toList());
+    } else {
+      return new ArrayList<>();
+    }
   }
   
   public List<String> getVideoURLs() {
-    return videos.values().stream()
-        .map(VideoDetails::getDownloadUrl)
-        .filter(StringUtils::isNotBlank)
-        .collect(Collectors.toList());
+    if (videos != null) {
+      return videos.values().stream()
+          .map(VideoDetails::getDownloadUrl)
+          .filter(StringUtils::isNotBlank)
+          .collect(Collectors.toList());
+    } else {
+      return new ArrayList<>();
+    }
   }
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
+++ b/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
@@ -21,6 +21,7 @@ import com.echobox.api.linkedin.jsonmapper.LinkedIn;
 import com.echobox.api.linkedin.types.LinkedInURNIdType;
 import com.echobox.api.linkedin.types.images.ImageDetails;
 import com.echobox.api.linkedin.types.urn.URN;
+import com.echobox.api.linkedin.types.videos.VideoDetails;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -203,6 +204,14 @@ public class Post extends LinkedInURNIdType {
   @Getter
   @Setter
   private Map<URN, ImageDetails> images;
+  
+  /**
+   * Mapping of video URN to video details.
+   * The video details will need to be retrieved via a separate API call and populated manually.
+   */
+  @Getter
+  @Setter
+  private Map<URN, VideoDetails> videos;
 
   public String getTitle() {
     Content content = this.getContent();
@@ -231,6 +240,13 @@ public class Post extends LinkedInURNIdType {
   public List<String> getImageURLs() {
     return images.values().stream()
         .map(ImageDetails::getDownloadUrl)
+        .filter(StringUtils::isNotBlank)
+        .collect(Collectors.toList());
+  }
+  
+  public List<String> getVideoURLs() {
+    return videos.values().stream()
+        .map(VideoDetails::getDownloadUrl)
         .filter(StringUtils::isNotBlank)
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/echobox/api/linkedin/types/videos/VideoDetails.java
+++ b/src/main/java/com/echobox/api/linkedin/types/videos/VideoDetails.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.videos;
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import com.echobox.api.linkedin.types.urn.URN;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VideoDetails {
+  
+  public VideoDetails(String downloadUrl) {
+    this.downloadUrl = downloadUrl;
+  }
+  
+  @LinkedIn
+  private URN owner;
+  
+  @LinkedIn
+  private URN id;
+  
+  @LinkedIn
+  private Long duration;
+  
+  @LinkedIn
+  private Float aspectRatioWidth;
+  
+  @LinkedIn
+  private Float aspectRatioHeight;
+  
+  @LinkedIn
+  private String downloadUrl;
+  
+  @LinkedIn
+  private Long downloadUrlExpiresAt;
+  
+  @LinkedIn
+  private String status;
+  
+  @LinkedIn
+  private String thumbnail;
+}


### PR DESCRIPTION
### Description of Changes
* Added support to retrieve video details from LinkedIn according to the [Sample response of the GET Video Request](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/videos-api?view=li-lms-2023-02&tabs=http):
```
{
   "duration": 32066,
   "aspectRatioWidth": 16,
   "owner": "urn:li:organization:18799005",
   "thumbnail": "https://media-exp1.licdn.com/dms/image/C4E10AQGUkQY7trgh-Q/ads-video-thumbnail_720_1280/0/1635274077531?e=2147483647&v=beta&t=_HxpoaXestMGYSqDyziZjUtzDvsp9zOgZvAy9HtVJZw",
   "downloadUrlExpiresAt": 1650549600000,
   "downloadUrl": "https://dms.licdn.com/playlist/C4E10AQGUkQY7trgh-Q/mp4-720p-30fp-crf28/0/1635274088269?e=2147483647&v=beta&t=tsv3E_sgOT1e7VPGpmrxk6ED7C0W3vwTh9Ui-8mlFZk",
   "id": "urn:li:video:C4E10AQGUkQY7trgh-Q",
   "aspectRatioHeight": 9,
   "captions": "https://www.linkedin.com/dms-mpf-uploads/C5510AQHHRzI0nYgcuw/ads-video-userUploadedThumbnail/0?ca=vector_ads&cn=uploads_secure&ccn=ambry-video&sync=0&v=beta&ut=0LIRxJwkoZQG81",
   "status": "AVAILABLE"
}
```
* Extended `Post` object to include video details mapping

### Documentation
N/A

### Risks & Impacts
N/A

### Testing
N/A

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.