### PR TITLE
SL-5347 Upgrade machine image to support Java 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ workflows:
 jobs:
   validate:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2204:2023.02.1
     steps:
       - checkout
       - run: 
@@ -51,7 +51,7 @@ jobs:
           command: source buildscripts/validate_build.sh
   maven_verify:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2204:2023.02.1
     steps:
       - checkout
       - run:
@@ -59,7 +59,7 @@ jobs:
           command: source buildscripts/mvn_verify.sh
   maven_deploy:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2204:2023.02.1
     steps:
       - checkout
       - run:


### PR DESCRIPTION
### Description of Changes

Machine image upgraded to one which supports for maven builds for Java 11 and Java 17 applications

### Documentation

N/A

### Risks & Impacts

No concerns

### Testing

This machine image is currently in use on the tiktok-sdk pipelines which involve compiling to Java 11

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.