### PR TITLE
SL-6725 Use 202306 as the default version of the LinkedIn API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,5 +188,5 @@ can get data for both organization and organization brand pages.
 ## 4.4.3 (April 24, 2023)
 *  Add missing CommentEntity field to CommentAction
 
-## 4.4.4 (Work in progress)
+## 4.4.4 (July 4, 2023)
 *  Update Versioned API to use the 202306 by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,3 +189,4 @@ can get data for both organization and organization brand pages.
 *  Add missing CommentEntity field to CommentAction
 
 ## 4.4.4 (Work in progress)
+*  Update Versioned API to use the 202306 by default

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultVersionedLinkedInClient.java
@@ -123,7 +123,7 @@ public class DefaultVersionedLinkedInClient extends BaseLinkedInClient
   /**
    * Default LinkedIn-version header
    */
-  public static final String DEFAULT_VERSIONED_MONTH = "202211";
+  public static final String DEFAULT_VERSIONED_MONTH = "202306";
   
   /**
    * Request header of protocol


### PR DESCRIPTION
### Description of Changes

Use 202306 as the default version of the LinkedIn API

### Documentation
N/A

### Risks & Impacts
Checking through the change logs, there is no supposed breaking changes.

### Testing
Tested locally using the Echobox App.

## Final Checklist

Please tick once completed.

- [X] Build passes.
- [X] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [X] Change log has been updated.