### PR TITLE
SL-6725 Update /networkSizes parameter value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,7 +191,7 @@ can get data for both organization and organization brand pages.
 ## 4.4.4 (July 4, 2023)
 *  Update Versioned API to use the 202306 by default
 
-## 4.4.5 (July 6, 2023)
+## 4.5.0 (July 6, 2023)
 * Update edgeType parameter value for the /networkSizes endpoint to be 
   COMPANY_FOLLOWED_BY_MEMBER instead of CompanyFollowedByMember. 
   This changed in the LinkedIn API 202305 release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,7 +191,7 @@ can get data for both organization and organization brand pages.
 ## 4.4.4 (July 4, 2023)
 *  Update Versioned API to use the 202306 by default
 
-## 4.4.5 (Work in progress)
+## 4.4.5 (July 6, 2023)
 * Update edgeType parameter value for the /networkSizes endpoint to be 
   COMPANY_FOLLOWED_BY_MEMBER instead of CompanyFollowedByMember. 
   This changed in the LinkedIn API 202305 release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,4 +192,6 @@ can get data for both organization and organization brand pages.
 *  Update Versioned API to use the 202306 by default
 
 ## 4.4.5 (Work in progress)
-
+* Update edgeType parameter value for the /networkSizes endpoint to be 
+  COMPANY_FOLLOWED_BY_MEMBER instead of CompanyFollowedByMember. 
+  This changed in the LinkedIn API 202305 release.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>4.4.5</version>
+  <version>4.5.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
@@ -84,7 +84,7 @@ public class VersionedOrganizationConnection extends VersionedConnection {
   private static final String ROLE_ASSIGNEE_VALUE = "roleAssignee";
   private static final String ORGANIZATION_VALUE = "organization";
   private static final String ORGANIZATIONAL_ENTITY_VALUE = "organizationalEntity";
-  private static final String COMPANY_FOLLOWED_BY_MEMBER_VALUE = "CompanyFollowedByMember";
+  private static final String COMPANY_FOLLOWED_BY_MEMBER_VALUE = "COMPANY_FOLLOWED_BY_MEMBER";
   
   /**
    * Instantiates a new connection base.


### PR DESCRIPTION
### Description of Changes
Endpoint /networkSizes has a parameter edgeType that takes a value. Up to and including the 202304 release of the LinkedIn API, the value was `CompanyFollowedByMember`. In the 202305 release, it has been changed to `COMPANY_FOLLOWED_BY_MEMBER`.

I updated the minor version as this is now incompatible with older versions of the linkedIn API. This is not strictly speaking a reason for updating the minor version but thought it highlights the difference.

### Documentation
N/A

### Risks & Impacts
N/A

### Testing
Using the Echobox App

## Final Checklist

Please tick once completed.

- [X] Build passes.
- [X] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [X] Change log has been updated.