### PR TITLE
Release 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,5 +191,7 @@ can get data for both organization and organization brand pages.
 ## 4.4.4 (July 4, 2023)
 *  Update Versioned API to use the 202306 by default
 
-## 4.4.5 (Work in progress)
-
+## 4.5.0 (July 6, 2023)
+* Update edgeType parameter value for the /networkSizes endpoint to be 
+  COMPANY_FOLLOWED_BY_MEMBER instead of CompanyFollowedByMember. 
+  This changed in the LinkedIn API 202305 release.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>4.4.5</version>
+  <version>4.5.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/versioned/VersionedOrganizationConnection.java
@@ -84,7 +84,7 @@ public class VersionedOrganizationConnection extends VersionedConnection {
   private static final String ROLE_ASSIGNEE_VALUE = "roleAssignee";
   private static final String ORGANIZATION_VALUE = "organization";
   private static final String ORGANIZATIONAL_ENTITY_VALUE = "organizationalEntity";
-  private static final String COMPANY_FOLLOWED_BY_MEMBER_VALUE = "CompanyFollowedByMember";
+  private static final String COMPANY_FOLLOWED_BY_MEMBER_VALUE = "COMPANY_FOLLOWED_BY_MEMBER";
   
   /**
    * Instantiates a new connection base.


### PR DESCRIPTION
### Description of Changes

Release 4.5.0 including the /networkSizes parameter value change

### Documentation

N/A

### Risks & Impacts

This version is not backwards compatible with the April 2023 LinkedIn API.


## Final Checklist

Please tick once completed.

- [X] Build passes.
- [X] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [X] Change log has been updated.