### PR TITLE
SL-9359 - Remove duplicate key in Post object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,4 +202,4 @@ can get data for both organization and organization brand pages.
 * Minor dependency updates
 
 # 4.5.2 (work in progress)
-
+* Remove duplicate key in Post object

--- a/src/main/java/com/echobox/api/linkedin/types/LinkedInURNIdType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/LinkedInURNIdType.java
@@ -26,6 +26,7 @@ import lombok.Getter;
  *
  * @author joanna
  */
+@Deprecated
 public class LinkedInURNIdType {
   
   /**

--- a/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
+++ b/src/main/java/com/echobox/api/linkedin/types/posts/Post.java
@@ -18,7 +18,6 @@
 package com.echobox.api.linkedin.types.posts;
 
 import com.echobox.api.linkedin.jsonmapper.LinkedIn;
-import com.echobox.api.linkedin.types.LinkedInURNIdType;
 import com.echobox.api.linkedin.types.images.ImageDetails;
 import com.echobox.api.linkedin.types.urn.URN;
 import com.echobox.api.linkedin.types.videos.VideoDetails;
@@ -47,7 +46,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @AllArgsConstructor
 @RequiredArgsConstructor
-public class Post extends LinkedInURNIdType {
+public class Post {
   
   /**
    * Urn of the author of this content.


### PR DESCRIPTION
### Description of Changes
The Post class already had its own id field, so didn't need to extend the `LinkedInURNIdType` class.

Addresses this issue: https://github.com/ebx/ebx-linkedin-sdk/issues/344

### Documentation
Update CHANGELOG

### Risks & Impacts
Minor, have tested locally.

### Testing
Ran locally and saw that posts could be made and that the log no longer appeared. I had seen it when running with the current latest version of the SDK.

### Deployment Considerations
I won't do a specific version release for this change.