### PR TITLE
Add additional URN entity types to the URNEntityType enum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,5 +201,6 @@ can get data for both organization and organization brand pages.
   to the LinkedIn endpoints.
 * Minor dependency updates
 
-# 4.5.2 (work in progress)
+# 4.6.0 (March 5, 2024)
+* Add additional URN entity types to URNEntityType enum
 * Remove duplicate key in Post object

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>4.5.2</version>
+  <version>4.6.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>4.5.2</version>
+  <version>4.6.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/types/urn/URNEntityType.java
+++ b/src/main/java/com/echobox/api/linkedin/types/urn/URNEntityType.java
@@ -54,7 +54,47 @@ public enum URNEntityType {
   /**
    * UGC post URN entity type.
    */
-  UGCPOST("ugcPost");
+  UGCPOST("ugcPost"),
+  /**
+   * UGC post URN entity type.
+   */
+  IMAGE("image"),
+  /**
+   * UGC post URN entity type.
+   */
+  DIGITALMEDIAASSET("ugcPost"),
+  /**
+   * UGC post URN entity type.
+   */
+  PERSON("person"),
+  /**
+   * UGC post URN entity type.
+   */
+  SPONSOREDACCOUNT("sponsoredAccount"),
+  /**
+   * UGC post URN entity type.
+   */
+  MEMBER("member"),
+  /**
+   * UGC post URN entity type.
+   */
+  COMPANY("company"),
+  /**
+   * UGC post URN entity type.
+   */
+  CSUSER("csUser"),
+  /**
+   * UGC post URN entity type.
+   */
+  COMMENT("comment"),
+  /**
+   * UGC post URN entity type.
+   */
+  ORIGINALARTICLE("originalArticle"),
+  /**
+   * UGC post URN entity type.
+   */
+  LIKE("like");
 
   /**
    * The string representation of the type


### PR DESCRIPTION
### Description of Changes

The key namespaces that I wanted to add are `IMAGE` and `DIGITALMEDIAASSET`. This was because an image URN should be input into `ImageConnection.retrieveImageDetails` and digital media assets are what are returned in the logoV2 object, which is an attribute in `Organization` instances. These need to be used in order to get the page profile URL for that organisation.

I added the rest because I saw that they existed, many of these are mentioned here: https://learn.microsoft.com/en-us/linkedin/shared/references/v2/urn-namespace.

### Documentation
Updated CHANGELOG, will do a minor version bump when this PR goes in.

### Risks & Impacts

### Testing
None.