### PR TITLE
Release version 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,3 +209,8 @@ can get data for both organization and organization brand pages.
 * Delete all deprecated code for V1 and V2 LinkedIn API endpoints and objects, the last of these
   endpoints were retired on June 30th 2023
 * Remove 'versioned' from class and variable names
+
+## 6.0.0 (March 7, 2024)
+* Stop accepting projection parameters when making API requests (support for this parameter was 
+  deprecated for different endpoints between 202305, 202306 and 202307) 
+* Update the default API version to 202307

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,3 +214,4 @@ can get data for both organization and organization brand pages.
 * Stop accepting projection parameters when making API requests (support for this parameter was 
   deprecated for different endpoints between 202305, 202306 and 202307) 
 * Update the default API version to 202307
+* Bump nexus-staging-maven-plugin version to 1.6.13

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>5.0.0</version>
+  <version>6.0.0</version>
 </dependency>
 ```
 
@@ -95,10 +95,7 @@ Retrieve an organization from LinkedIn
     
     VersionedOrganizationConnection connection = 
         new VersionedOrganizationConnection(linkedInClient);
-    Organization organization = connection.retrieveOrganization(organizationURN, Parameter
-            .with("projection",
-                "(elements*(*,roleAssignee~(localizedFirstName, localizedLastName),"
-                    + "organizationalTarget~(localizedName)))"));
+    Organization organization = connection.retrieveOrganization(organizationURN, null);
 
 ## Getting in touch
 

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>5.0.0</version>
+  <version>6.0.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
@@ -123,7 +123,7 @@ public class DefaultLinkedInClient extends BaseLinkedInClient
   /**
    * Default LinkedIn-version header
    */
-  public static final String DEFAULT_VERSIONED_MONTH = "202306";
+  public static final String DEFAULT_VERSIONED_MONTH = "202307";
   
   /**
    * Request header of protocol

--- a/src/main/java/com/echobox/api/linkedin/connection/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/OrganizationConnection.java
@@ -121,8 +121,8 @@ public class OrganizationConnection extends Connection {
    * @param count the number of entries to be returned per paged request
    * @return The organization with the vanity name
    */
-  public List<OrganizationBase> findOrganizationByVanityName(String vanityName,
-      Parameter fields, Integer count) {
+  public List<OrganizationBase> findOrganizationByVanityName(String vanityName, Parameter fields,
+      Integer count) {
     ValidationUtils.verifyParameterPresence(VANITY_NAME_VALUE, vanityName);
     
     List<Parameter> parameters = new ArrayList<>();
@@ -209,15 +209,14 @@ public class OrganizationConnection extends Connection {
    * Access Control</a>
    * @param role Limit results to specific roles, such as ADMINISTRATOR.
    * @param state Limit results to specific role states, such as APPROVED.
-   * @param projection Field projection
    * @param count the number of entries to be returned per paged request
    * @return List of access controls for a given role and state for the member
    */
   public List<AccessControl> retrieveMemberOrganizationAccessControl(String role, String state,
-      Parameter projection, Integer count) {
+      Integer count) {
     List<Parameter> params = new ArrayList<>();
     params.add(Parameter.with(QUERY_KEY, ROLE_ASSIGNEE_VALUE));
-    addRoleStateParams(role, state, projection, params);
+    addRoleStateParams(role, state, params);
     addStartAndCountParams(params, null, count);
     
     return getListFromQuery(ORGANIZATION_ACLS, AccessControl.class,
@@ -232,18 +231,17 @@ public class OrganizationConnection extends Connection {
    * is retrieved.
    * @param role Limit results to specific roles
    * @param state Limit results to specific role states
-   * @param projection Field projection
    * @param count the number of entries to be returned per paged request
    * @return List of access controls for an organization
    */
-  public List<AccessControl> findOrganizationAccessControl(URN organizationURN,
-      String role, String state, Parameter projection, Integer count) {
+  public List<AccessControl> findOrganizationAccessControl(URN organizationURN, String role,
+      String state, Integer count) {
     validateOrganizationURN("organization", organizationURN);
     
     List<Parameter> parameters = new ArrayList<>();
     parameters.add(Parameter.with(QUERY_KEY, ORGANIZATION_VALUE));
     parameters.add(Parameter.with(ORGANIZATION_KEY, organizationURN.toString()));
-    addRoleStateParams(role, state, projection, parameters);
+    addRoleStateParams(role, state, parameters);
     addStartAndCountParams(parameters, null, count);
     
     return getListFromQuery(ORGANIZATION_ACLS, AccessControl.class,
@@ -266,10 +264,9 @@ public class OrganizationConnection extends Connection {
     
     addParametersForStatistics(organizationURN, null, parameters);
     addStartAndCountParams(parameters, null, count);
-    
+  
     return getListFromQuery(ORGANIZATIONAL_ENTITY_FOLLOWER_STATS,
-        OrganizationFollowerStatistics.class,
-        parameters.toArray(new Parameter[0]));
+        OrganizationFollowerStatistics.class, parameters.toArray(new Parameter[0]));
   }
   
   /**
@@ -446,16 +443,12 @@ public class OrganizationConnection extends Connection {
     validateURN(type, urn);
   }
   
-  private void addRoleStateParams(String role, String state, Parameter projection,
-      List<Parameter> parameters) {
+  private void addRoleStateParams(String role, String state, List<Parameter> parameters) {
     if (StringUtils.isNotBlank(role)) {
       parameters.add(Parameter.with(ROLE_KEY, role));
     }
     if (StringUtils.isNotBlank(state)) {
       parameters.add(Parameter.with(STATE_KEY, state));
-    }
-    if (projection != null) {
-      parameters.add(projection);
     }
   }
   


### PR DESCRIPTION
### Description of Changes
See commits included.

### Documentation
Changelog updated.

### Risks & Impacts
Users wishing to take any version releases after this one will not be able to pass in projections into the updated interfaces, even if they are using older versions. Note though that the previous version (`202306`) is deprecated in June.

### Testing
Have confirmed that using projection parameters fail when using version `202307`.
