### PR TITLE
SL-9774 Add support for ugcPost URNs in the retrieveShareStatistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,3 +215,7 @@ can get data for both organization and organization brand pages.
   deprecated for different endpoints between 202305, 202306 and 202307) 
 * Update the default API version to 202307
 * Bump nexus-staging-maven-plugin version to 1.6.13
+
+## 6.0.1 (March 15, 2024)
+* OrganizationConnection.retrieveShareStatistics now accepts ugcPost type post URNs in addition
+  to the existing share type post URNs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,6 @@ can get data for both organization and organization brand pages.
 * Update the default API version to 202307
 * Bump nexus-staging-maven-plugin version to 1.6.13
 
-## 6.0.1 (March 15, 2024)
+## 6.0.1 (March 12, 2024)
 * OrganizationConnection.retrieveShareStatistics now accepts ugcPost type post URNs in addition
   to the existing share type post URNs.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>6.0.0</version>
+  <version>6.0.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>6.0.0</version>
+  <version>6.0.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/connection/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/OrganizationConnection.java
@@ -364,7 +364,7 @@ public class OrganizationConnection extends Connection {
     params.add(Parameter.with(ORGANIZATIONAL_ENTITY_KEY, organizationURN));
     
     if (shareURNs != null && !shareURNs.isEmpty()) {
-      // Validate and separate out ugcPosts and share posts
+      // Validate and separate out share and ugcPost posts
       Pair<List<URN>, List<URN>> urns = getValidShareAndUGCPostURNs(shareURNs);
       if (!urns.getLeft().isEmpty()) {
         addParametersFromURNs(params, SHARES_PARAM_KEY, urns.getLeft());

--- a/src/main/java/com/echobox/api/linkedin/connection/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/OrganizationConnection.java
@@ -367,10 +367,10 @@ public class OrganizationConnection extends Connection {
       // Validate and separate out ugcPosts and share posts
       Pair<List<URN>, List<URN>> urns = getValidShareAndUGCPostURNs(shareURNs);
       if (!urns.getLeft().isEmpty()) {
-        addParametersFromURNs(params, SHARES_PARAM_KEY, shareURNs);
+        addParametersFromURNs(params, SHARES_PARAM_KEY, urns.getLeft());
       }
       if (!urns.getRight().isEmpty()) {
-        addParametersFromURNs(params, UGCPOSTS_PARAM_KEY, shareURNs);
+        addParametersFromURNs(params, UGCPOSTS_PARAM_KEY, urns.getRight());
       }
     }
     

--- a/src/main/java/com/echobox/api/linkedin/connection/OrganizationConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/OrganizationConnection.java
@@ -76,6 +76,7 @@ public class OrganizationConnection extends Connection {
   private static final String ORGANIZATIONAL_ENTITY_KEY = "organizationalEntity";
   private static final String EDGE_TYPE_KEY = "edgeType";
   private static final String SHARES_PARAM_KEY = "shares";
+  private static final String UGCPOSTS_PARAM_KEY = "ugcPosts";
   
   /**
    * Param value
@@ -366,10 +367,10 @@ public class OrganizationConnection extends Connection {
       // Validate and separate out ugcPosts and share posts
       Pair<List<URN>, List<URN>> urns = getValidShareAndUGCPostURNs(shareURNs);
       if (!urns.getLeft().isEmpty()) {
-        addParametersFromURNs(params, "shares", shareURNs);
+        addParametersFromURNs(params, SHARES_PARAM_KEY, shareURNs);
       }
       if (!urns.getRight().isEmpty()) {
-        addParametersFromURNs(params, "ugcPosts", shareURNs);
+        addParametersFromURNs(params, UGCPOSTS_PARAM_KEY, shareURNs);
       }
     }
     


### PR DESCRIPTION
### Description of Changes
Previously, only `share` type post URNs were allowed when getting the statistics for individual LinkedIn post. This change
allows `ugcPost` type URNs when retrieving post statistics as well.

### Documentation
n/a

### Risks & Impacts

The risks are minimal as there are no breaking changes. It just allows an addition post type to have statistics retrieved.

### Testing

Tested in calling app.

## Final Checklist

Please tick once completed.

- [X] Build passes.
- [X] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [X] Change log has been updated.