### PR TITLE
SL-9924 Update CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ workflows:
 
 jobs:
   validate:
-    docker:
-      - image: cimg/openjdk:8.0
+    machine:
+      image: ubuntu-2204:2024.01.2
     steps:
       - checkout
       - run: 
@@ -50,16 +50,16 @@ jobs:
           name: "Validate build"
           command: source buildscripts/validate_build.sh
   maven_verify:
-    docker:
-      - image: cimg/openjdk:8.0
+    machine:
+      image: ubuntu-2204:2024.01.2
     steps:
       - checkout
       - run:
           name: "Perform Maven Verify"
           command: source buildscripts/mvn_verify.sh
   maven_deploy:
-    docker:
-      - image: cimg/openjdk:8.0
+    machine:
+      image: ubuntu-2204:2024.01.2
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ workflows:
 
 jobs:
   validate:
-    machine:
+    docker:
       image: cimg/openjdk:8.0
     steps:
       - checkout
@@ -50,7 +50,7 @@ jobs:
           name: "Validate build"
           command: source buildscripts/validate_build.sh
   maven_verify:
-    machine:
+    docker:
       image: cimg/openjdk:8.0
     steps:
       - checkout
@@ -58,7 +58,7 @@ jobs:
           name: "Perform Maven Verify"
           command: source buildscripts/mvn_verify.sh
   maven_deploy:
-    machine:
+    docker:
       image: cimg/openjdk:8.0
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ workflows:
 
 jobs:
   validate:
-    machine:
-      image: ubuntu-2204:2024.01.2
+    docker:
+      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - run: 
@@ -50,16 +50,16 @@ jobs:
           name: "Validate build"
           command: source buildscripts/validate_build.sh
   maven_verify:
-    machine:
-      image: ubuntu-2204:2024.01.2
+    docker:
+      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - run:
           name: "Perform Maven Verify"
           command: source buildscripts/mvn_verify.sh
   maven_deploy:
-    machine:
-      image: ubuntu-2204:2024.01.2
+    docker:
+      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ workflows:
 jobs:
   validate:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: cimg/openjdk:8.0
     steps:
       - checkout
       - run: 
@@ -51,7 +51,7 @@ jobs:
           command: source buildscripts/validate_build.sh
   maven_verify:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: cimg/openjdk:8.0
     steps:
       - checkout
       - run:
@@ -59,7 +59,7 @@ jobs:
           command: source buildscripts/mvn_verify.sh
   maven_deploy:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: cimg/openjdk:8.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ workflows:
 jobs:
   validate:
     docker:
-      image: cimg/openjdk:8.0
+      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - run: 
@@ -51,7 +51,7 @@ jobs:
           command: source buildscripts/validate_build.sh
   maven_verify:
     docker:
-      image: cimg/openjdk:8.0
+      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - run:
@@ -59,7 +59,7 @@ jobs:
           command: source buildscripts/mvn_verify.sh
   maven_deploy:
     docker:
-      image: cimg/openjdk:8.0
+      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,3 +219,7 @@ can get data for both organization and organization brand pages.
 ## 6.0.1 (March 12, 2024)
 * OrganizationConnection.retrieveShareStatistics now accepts ugcPost type post URNs in addition
   to the existing share type post URNs.
+
+## 6.0.2 (April 26. 2024)
+* Update the CircleCI Build image form ubuntu-2004 to cimg/openjdk:8.0
+

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>6.0.1</version>
+  <version>6.0.2</version>
 </dependency>
 ```
 

--- a/buildscripts/mvn_verify.sh
+++ b/buildscripts/mvn_verify.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 
 ## For PR builds, perform maven verify. Exit with error if dev or master 
 ## as these are handled separately in mvn_deploy.sh
-
+printenv
 if [ "$CIRCLE_BRANCH" == "${DEV_BRANCH}" ] || [ "$CIRCLE_BRANCH" == "${RELEASE_BRANCH}" ]; then
   printf "${RED_COLOUR}ERROR: PR builds should not be triggered by ${DEV_BRANCH} or ${RELEASE_BRANCH} branches.${NO_COLOUR}\n"
   exit 1

--- a/buildscripts/mvn_verify.sh
+++ b/buildscripts/mvn_verify.sh
@@ -20,7 +20,8 @@ set -euo pipefail
 
 ## For PR builds, perform maven verify. Exit with error if dev or master 
 ## as these are handled separately in mvn_deploy.sh
-printenv
+export JAVA_HOME="/usr"
+
 if [ "$CIRCLE_BRANCH" == "${DEV_BRANCH}" ] || [ "$CIRCLE_BRANCH" == "${RELEASE_BRANCH}" ]; then
   printf "${RED_COLOUR}ERROR: PR builds should not be triggered by ${DEV_BRANCH} or ${RELEASE_BRANCH} branches.${NO_COLOUR}\n"
   exit 1

--- a/buildscripts/mvn_verify.sh
+++ b/buildscripts/mvn_verify.sh
@@ -20,8 +20,6 @@ set -euo pipefail
 
 ## For PR builds, perform maven verify. Exit with error if dev or master 
 ## as these are handled separately in mvn_deploy.sh
-export JAVA_HOME="/usr"
-
 if [ "$CIRCLE_BRANCH" == "${DEV_BRANCH}" ] || [ "$CIRCLE_BRANCH" == "${RELEASE_BRANCH}" ]; then
   printf "${RED_COLOUR}ERROR: PR builds should not be triggered by ${DEV_BRANCH} or ${RELEASE_BRANCH} branches.${NO_COLOUR}\n"
   exit 1

--- a/buildscripts/mvn_verify.sh
+++ b/buildscripts/mvn_verify.sh
@@ -20,11 +20,12 @@ set -euo pipefail
 
 ## For PR builds, perform maven verify. Exit with error if dev or master 
 ## as these are handled separately in mvn_deploy.sh
+
 if [ "$CIRCLE_BRANCH" == "${DEV_BRANCH}" ] || [ "$CIRCLE_BRANCH" == "${RELEASE_BRANCH}" ]; then
   printf "${RED_COLOUR}ERROR: PR builds should not be triggered by ${DEV_BRANCH} or ${RELEASE_BRANCH} branches.${NO_COLOUR}\n"
   exit 1
 else
   printf "${GREEN_COLOUR}Performing a PR verify build on PR #${CIRCLE_PULL_REQUEST##*/}.${NO_COLOUR}\n"
-  java --version
+  java -version
   mvn clean verify
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>6.0.1</version>
+  <version>6.0.2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.15.0</version>
+            <version>9.3</version>
           </dependency>
           <dependency>
             <groupId>com.github.sevntu-checkstyle</groupId>


### PR DESCRIPTION
### Description of Changes
The image used to build and deploy from circle ci is updated from ubuntu-2004 to cimg/openjdk:8.0 docker image instead of machine image. This allowed the use of Java 8 to compile while the latest ubuntu machine image uses Java 17.

Also downgraded checkstyle as V10.x+ does not support Java 8.

### Documentation
No need as it only changes the build environment

### Risks & Impacts

Minimal

### Testing
Run the build. The deployment phase can only be tested when a new version is released.

## Final Checklist

Please tick once completed.

- [X] Build passes.
- [X] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [X] Change log has been updated.