### PR TITLE
SL-5334 Update to Java 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ workflows:
 jobs:
   validate:
     docker:
-      - image: cimg/openjdk:8.0
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - run: 
@@ -51,7 +51,7 @@ jobs:
           command: source buildscripts/validate_build.sh
   maven_verify:
     docker:
-      - image: cimg/openjdk:8.0
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - run:
@@ -59,7 +59,7 @@ jobs:
           command: source buildscripts/mvn_verify.sh
   maven_deploy:
     docker:
-      - image: cimg/openjdk:8.0
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,3 +223,5 @@ can get data for both organization and organization brand pages.
 ## 6.0.2 (April 26. 2024)
 * Update the CircleCI Build image form ubuntu-2004 to cimg/openjdk:8.0
 
+## 7.0.0 (April 26, 2024)
+* Update build form Java 8 to Java 11. This included updating the build image to cimg/openjdk:11.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,7 +221,7 @@ can get data for both organization and organization brand pages.
   to the existing share type post URNs.
 
 ## 6.0.2 (April 26. 2024)
-* Update the CircleCI Build image form ubuntu-2004 to cimg/openjdk:8.0
+* Update the CircleCI Build image from ubuntu-2004 to cimg/openjdk:8.0
 
 ## 7.0.0 (April 26, 2024)
 * Update build form Java 8 to Java 11. This included updating the build image to cimg/openjdk:11.0.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>6.0.2</version>
+  <version>7.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,14 +8,13 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>6.0.2</version>
+  <version>7.0.0</version>
   <packaging>jar</packaging>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <licenses>
@@ -177,7 +176,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>9.3</version>
+            <version>10.15.0</version>
           </dependency>
           <dependency>
             <groupId>com.github.sevntu-checkstyle</groupId>


### PR DESCRIPTION
### Description of Changes

Update build to Java 11

### Documentation

Updated readme and changelog.

### Risks & Impacts

Users of the ebx-linkedin-sdk can no longer link Java 8 projects.

### Testing
Tested locally, but as most of the changes are build related, the build has also been checked.

## Final Checklist

Please tick once completed.

- [X] Build passes.
- [X] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [X] Change log has been updated.