### PR TITLE
SL-5336 Refactor GET and DELETE requests to use Java 11 HTTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,3 +225,6 @@ can get data for both organization and organization brand pages.
 
 ## 7.0.0 (April 26, 2024)
 * Update build from Java 8 to Java 11. This included updating the build image to cimg/openjdk:11.0.
+
+## 7.1.0 (May 3, 2024)
+* Update GET and DELETE requests to use Java 11's HTTP Client.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>8.0.0</version>
+  <version>7.1.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>7.0.0</version>
+  <version>8.0.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -583,6 +583,9 @@ public class DefaultWebRequestor implements WebRequestor {
       
       return getResponse(builder.build());
     } catch (URISyntaxException | InterruptedException ex) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(format("LinkedIn responded with an error %s", ex.getMessage()));
+      }
       throw new IOException(ex);
     }
   }
@@ -615,11 +618,10 @@ public class DefaultWebRequestor implements WebRequestor {
   private void fillHeaderAndDebugInfo(java.net.http.HttpHeaders httpHeaders) {
     currentHttpHeaders = httpHeaders;
   
-    String liFabric = StringUtils.trimToEmpty(httpHeaders.firstValue("x-li-fabric").orElse(null));
-    String liFormat = StringUtils.trimToEmpty(httpHeaders.firstValue("x-li-format").orElse(null));
-    String liRequestId = StringUtils.trimToEmpty(httpHeaders.firstValue(
-        "x-li-request-id").orElse(null));
-    String liUUID = StringUtils.trimToEmpty(httpHeaders.firstValue("x-li-uuid").orElse(null));
+    String liFabric = httpHeaders.firstValue("x-li-fabric").orElse("");
+    String liFormat = httpHeaders.firstValue("x-li-format").orElse("");
+    String liRequestId =httpHeaders.firstValue("x-li-request-id").orElse("");
+    String liUUID = httpHeaders.firstValue("x-li-uuid").orElse("");
     debugHeaderInfo = new DebugHeaderInfo(liFabric, liFormat, liRequestId, liUUID);
   }
   

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -584,7 +584,7 @@ public class DefaultWebRequestor implements WebRequestor {
       return getResponse(builder.build());
     } catch (URISyntaxException | InterruptedException ex) {
       if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug(format("LinkedIn responded with an error %s", ex.getMessage()));
+        LOGGER.debug("LinkedIn responded with an error {}", ex.getMessage());
       }
       throw new IOException(ex);
     }

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -120,7 +120,7 @@ public class DefaultWebRequestor implements WebRequestor {
 
   private Map<String, Object> currentHeaders;
   
-  private java.net.http.HttpHeaders currentHttpHeaders;
+  private Map<String, List<String>> currentHttpHeaders;
 
   private DebugHeaderInfo debugHeaderInfo;
 
@@ -524,20 +524,20 @@ public class DefaultWebRequestor implements WebRequestor {
   }
 
   /**
-   * access to the current response headers
+   * Access to the current response headers
    * 
-   * @return the current reponse header map
+   * @return the current response header map
    */
   public Map<String, Object> getCurrentHeaders() {
     return currentHeaders;
   }
   
   /**
-   * access to the current response headers
+   * Access to the current response headers
    *
-   * @return the current reponse header map
+   * @return the current response header map
    */
-  public java.net.http.HttpHeaders getCurrentHttpHeaders() {
+  public Map<String, List<String>> getCurrentHttpHeaders() {
     return currentHttpHeaders;
   }
   
@@ -616,7 +616,7 @@ public class DefaultWebRequestor implements WebRequestor {
   }
   
   private void fillHeaderAndDebugInfo(java.net.http.HttpHeaders httpHeaders) {
-    currentHttpHeaders = httpHeaders;
+    currentHttpHeaders = httpHeaders.map();
   
     String liFabric = httpHeaders.firstValue("x-li-fabric").orElse("");
     String liFormat = httpHeaders.firstValue("x-li-format").orElse("");

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -460,6 +460,16 @@ public class DefaultWebRequestor implements WebRequestor {
   protected void customizeConnection(HttpRequest connection) {
     // This implementation is a no-op
   }
+  
+  /**
+   * Hook method which allows subclasses to easily customise the HTTP request connection
+   * This implementation is a no-op.
+   *
+   * @param connection The connection to customize.
+   */
+  protected void customizeConnection(java.net.http.HttpRequest.Builder connection) {
+    // This implementation is a no-op
+  }
 
   /**
    * Attempts to cleanly close a resource, swallowing any exceptions that might occur since 
@@ -579,6 +589,7 @@ public class DefaultWebRequestor implements WebRequestor {
         builder.headers(headers.toArray(new String[0]));
       }
       
+      customizeConnection(builder);
       requestBuilder.accept(builder);
       
       return getResponse(builder.build());

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -235,7 +235,7 @@ public class DefaultWebRequestor implements WebRequestor {
 
   @Override
   public Response executeGet(String url) throws IOException {
-    return executeGet(url);
+    return executeGet(url, null);
   }
   
   @Override

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultWebRequestor.java
@@ -620,7 +620,7 @@ public class DefaultWebRequestor implements WebRequestor {
   
     String liFabric = httpHeaders.firstValue("x-li-fabric").orElse("");
     String liFormat = httpHeaders.firstValue("x-li-format").orElse("");
-    String liRequestId =httpHeaders.firstValue("x-li-request-id").orElse("");
+    String liRequestId = httpHeaders.firstValue("x-li-request-id").orElse("");
     String liUUID = httpHeaders.firstValue("x-li-uuid").orElse("");
     debugHeaderInfo = new DebugHeaderInfo(liFabric, liFormat, liRequestId, liUUID);
   }


### PR DESCRIPTION
### Description of Changes
- Refactor the more straightforward methods, GET and DELETE to use the Java 11 HTTP client
- Used tiktok equivalent [PR](https://github.com/ebx/ebx-tiktok-sdk/commit/a9d37d3080f10a4b4ca1bc84622917708f3717d8#) as base for the changes. Needed to add changes to authorisation so they are in line with linkedin's API requests with `Authorization` header and `Bearer` 
- Changes for PUT and POST requests will come in a follow-up PR

### Documentation

N/A

### Risks & Impacts
Risky as it affects all interactions with the LinkedIn API, will be tested thoroughly though.

### Testing
Tested locally in main (built version `7.1.0` locally and used that) by sharing (GET requests also used here) and deleting a post on LinkedIn without any issues.

## Final Checklist

Please tick once completed.

- [X] Build passes.
- [X] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements). -- I used a minor bump as it is a backwards compatible change but not a bug fix.
- [X] Change log has been updated.