### PR TITLE
SL-3087 - Replace references to Travis CI with CircleCI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,3 +230,6 @@ can get data for both organization and organization brand pages.
 * Update HTTP requests to use Java 11's HTTP client instead of the Google HTTP client.
 * Some backwards incompatible changes introduced such as return type of `getCurrentHeaders` and 
 parameter type of `customizeConnection`
+
+## 8.0.1 (not yet released)
+* Updated contributing notes to specify CircleCI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,10 +226,8 @@ can get data for both organization and organization brand pages.
 ## 7.0.0 (April 26, 2024)
 * Update build from Java 8 to Java 11. This included updating the build image to cimg/openjdk:11.0.
 
-## 8.0.0 (May 13, 2024)
+## 8.0.0 (May 14, 2024)
 * Update HTTP requests to use Java 11's HTTP client instead of the Google HTTP client.
 * Some backwards incompatible changes introduced such as return type of `getCurrentHeaders` and 
 parameter type of `customizeConnection`
-
-## 8.0.1 (not yet released)
-* Updated contributing notes to specify CircleCI
+* Updated contributing notes to reference CircleCI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to ebx-linkedin-sdk
 
-Contributing code is an essential part of open source and we try to make this as easy as possible. There are several ways you can contribute to ebx-linkedin-sdk.  Here are some guidelines for creating new issues and sending us pull requests. Please read them carefully before contributing.
+Contributing code is an essential part of open source, and we try to make this as easy as possible. There are several ways you can contribute to ebx-linkedin-sdk.  Here are some guidelines for creating new issues and sending us pull requests. Please read them carefully before contributing.
 
 ## How to create a new issue
 
@@ -29,9 +29,10 @@ Pull requests (PR) are a very important way to contribute code to the library. W
   
         GH-123 Fixed NPE exception when resvoling an organisation
 
-* The pull request should be mergeable, i.e. no conflicts.
+* The pull request should be merge-able, i.e. no conflicts.
 * Junit tests required for any functional change must be included.
-* The pull request should be targetted at the `dev` branch. If you raise it against `master` the PR will fail to build.
-* Please try to keep PR commits in a logical order incase we need to review each commit seperately, but generally speaking the fewer commits the better.
-* Your PR will have to build succesfully against our CI (we use [Travis CI](https://travis-ci.org/ebx/ebx-linkedin-sdk)).
+* The pull request should be targeted at the `dev` branch. If you raise it against `master` the PR will fail to build.
+* Please try to keep PR commits in a logical order in case we need to review each commit 
+  separately, but generally speaking the fewer commits the better.
+* Your PR will have to build successfully against our CI (we use [CircleCI](https://app.circleci.com/pipelines/github/ebx/ebx-linkedin-sdk)).
 * **Important Note**: If your PR contains breaking changes you must include a MAJOR version bump in the PR.

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>7.0.0</version>
+  <version>8.0.1</version>
 </dependency>
 ```
 
 ## Installation (Most Up To Date)
-[![Build Status](https://travis-ci.org/ebx/ebx-linkedin-sdk.svg?branch=dev)](https://app.travis-ci.com/github/ebx/ebx-linkedin-sdk)
+[![ebx-linkedin-sdk](https://circleci.com/gh/ebx/ebx-linkedin-sdk.svg?style=svg)](https://app.circleci.com/pipelines/github/ebx/ebx-linkedin-sdk)
 
 If you'd like to use the latest SNAPSHOT build please ensure you have snapshots enabled in your pom:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>8.0.1</version>
+  <version>8.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>8.0.1</version>
+  <version>8.0.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>8.0.0</version>
+  <version>8.0.1</version>
   <packaging>jar</packaging>
 
   <properties>


### PR DESCRIPTION
### Description of Changes

CircleCI is now used for builds. So the readme and contribution notes should reference it.

I followed [these instructions](https://circleci.com/docs/status-badges/) for the status badge. I don't think it will work when the status is [reported](https://app.circleci.com/pipelines/github/ebx/ebx-linkedin-sdk) as unauthorized - it will just show failed in this case. However, the link it is replacing is invalid and always showed that it was passing, so this is making it no worse.

### Documentation
See diff! The status reporting may not be completely accurate, see above.

### Risks & Impacts
No code changes.

### Testing
None.