### PR TITLE
Retrieve image details

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>validate</id>

--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.surefire</groupId>
             <artifactId>surefire-junit47</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -272,7 +272,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.7.0</version>
+            <version>3.8.0</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.surefire</groupId>
             <artifactId>surefire-junit47</artifactId>
-            <version>3.2.1</version>
+            <version>3.3.0</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.22.0</version>
+        <version>3.23.0</version>
         <executions>
           <execution>
             <id>cpd</id>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
           <dependency>
             <groupId>org.apache.maven.surefire</groupId>
             <artifactId>surefire-junit47</artifactId>
-            <version>3.3.0</version>
+            <version>3.4.0</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.23.0</version>
+        <version>3.24.0</version>
         <executions>
           <execution>
             <id>cpd</id>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.15.0</version>
+      <version>3.16.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>validate</id>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.16.0</version>
+            <version>10.17.0</version>
           </dependency>
           <dependency>
             <groupId>com.github.sevntu-checkstyle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.0</version>
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.surefire</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.24.0</version>
+        <version>3.25.0</version>
         <executions>
           <execution>
             <id>cpd</id>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.16.0</version>
+      <version>3.17.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.14.0</version>
+      <version>3.15.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -272,7 +272,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.6.0</version>
+            <version>3.7.0</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.13</version>
+            <version>1.7.0</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.10.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -272,7 +272,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.8.0</version>
+            <version>3.10.0</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.17.0</version>
+            <version>10.18.0</version>
           </dependency>
           <dependency>
             <groupId>com.github.sevntu-checkstyle</groupId>

--- a/src/main/java/com/echobox/api/linkedin/connection/ImageConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/ImageConnection.java
@@ -24,7 +24,6 @@ import com.echobox.api.linkedin.types.images.ImageDetails;
 import com.echobox.api.linkedin.types.images.InitializeUpload;
 import com.echobox.api.linkedin.types.images.InitializeUploadRequestBody;
 import com.echobox.api.linkedin.types.urn.URN;
-import com.echobox.api.linkedin.util.URLUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -138,7 +137,7 @@ public class ImageConnection extends Connection {
    * @return the image details
    */
   public ImageDetails retrieveImageDetails(URN imageURN) {
-    return linkedinClient.fetchObject(IMAGES + "/" + URLUtils.urlEncode(imageURN.toString()),
+    return linkedinClient.fetchObject(IMAGES + "/" + imageURN.toString(),
         ImageDetails.class);
   }
 }


### PR DESCRIPTION
### Description of Changes

This change fixes the retrieveImageDetails method by removing the UrlEncode operation that is not required according to the official documentation (accessible in the Javadoc for the same method).

### Documentation

https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api#get-a-single-image

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.