### PR TITLE
SL-9350 Fix up before release including updating the default API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,5 +233,5 @@ parameter type of `customizeConnection`
 * Updated contributing notes to reference CircleCI
 
 ## 8.0.1 (November 28, 2024)
-* Update the default API version to 202411
-* Update a number of dependencies, including org.apache.commons:commons-lang3 to 3.17.0
+* Update the default API version to 202411.
+* Update a number of dependencies, including org.apache.commons:commons-lang3 to 3.17.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,3 +231,7 @@ can get data for both organization and organization brand pages.
 * Some backwards incompatible changes introduced such as return type of `getCurrentHeaders` and 
 parameter type of `customizeConnection`
 * Updated contributing notes to reference CircleCI
+
+## 8.0.1 (November 28, 2024)
+* Update the default API version to 202411
+* Update a number of dependencies, including org.apache.commons:commons-lang3 to 3.17.0

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>8.0.0</version>
+  <version>8.0.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>8.0.0</version>
+  <version>8.0.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
@@ -112,7 +112,7 @@ public class DefaultLinkedInClient extends BaseLinkedInClient
   /**
    * Default LinkedIn-version header
    */
-  public static final String DEFAULT_VERSIONED_MONTH = "202307";
+  public static final String DEFAULT_VERSIONED_MONTH = "202411";
   
   /**
    * Knows how to map Graph API exceptions to formal Java exception types.


### PR DESCRIPTION
### Description of Changes
Updates the version number of the project.
Updates the default LinkedIn API version number to the latest.
Updates the project documentation.

### Documentation

N/A

### Risks & Impacts

the only risk is in updating the default LinkedIn API version and that can be overridden by the caller.

### Testing

Ran the unit tests and tested against the Echobox.

## Final Checklist

Please tick once completed.

- [X] Build passes.
- [X] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [X] Change log has been updated.