### PR TITLE
SL-14892 Add support for People Typeahead API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,3 +239,6 @@ parameter type of `customizeConnection`
 ## 8.0.2 (December 11, 2024)
 * Revert back to using Google HTTP client for HTTP requests (after encountering issues with 
   LinkedIn reconnections)
+
+## 8.1.0 (August 27, 2025)
+* Add support for LinkedIn's People Typeahead API to search for an organization's followers.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>8.0.2</version>
+  <version>8.1.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/connection/PeopleConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/PeopleConnection.java
@@ -47,18 +47,18 @@ public class PeopleConnection extends Connection {
    * Search followers of an organization by keyword.
    *
    * @param organizationURN URN of the organization (urn:li:organization:{id})
-   * @param keywords The search string (partial name, etc.)
+   * @param keyword The search string (partial name, etc.)
    * @param count Max number of results to return
    * @return list of follower results with URNs, names, headline, photo, etc.
    */
-  public List<FollowerResult> searchOrganizationFollowers(URN organizationURN, String keywords,
+  public List<FollowerResult> searchOrganizationFollowers(URN organizationURN, String keyword,
       Integer count) {
     ValidationUtils.verifyParameterPresence("organizationURN", organizationURN);
-    ValidationUtils.verifyParameterPresence("keywords", keywords);
+    ValidationUtils.verifyParameterPresence("keywords", keyword);
     
     List<Parameter> params = new ArrayList<>();
     params.add(Parameter.with(QUERY_KEY, ORG_FOLLOWERS_VALUE));
-    params.add(Parameter.with(KEYWORDS_KEY, keywords));
+    params.add(Parameter.with(KEYWORDS_KEY, keyword));
     params.add(Parameter.with(ORG_KEY, organizationURN.toString()));
     this.addStartAndCountParams(params, null, count);
     

--- a/src/main/java/com/echobox/api/linkedin/connection/PeopleConnection.java
+++ b/src/main/java/com/echobox/api/linkedin/connection/PeopleConnection.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.connection;
+
+import com.echobox.api.linkedin.client.LinkedInClient;
+import com.echobox.api.linkedin.client.Parameter;
+import com.echobox.api.linkedin.types.people.FollowerResult;
+import com.echobox.api.linkedin.types.urn.URN;
+import com.echobox.api.linkedin.util.ValidationUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * People Connection class for LinkedIn People (via Typeahead API).
+ *
+ * @author Myrto Papakonstantinou
+ */
+public class PeopleConnection extends Connection {
+  
+  private static final String PEOPLE_TYPEAHEAD = "/peopleTypeahead";
+  private static final String QUERY_KEY = "q";
+  private static final String KEYWORDS_KEY = "keywords";
+  private static final String ORG_KEY = "organization";
+  private static final String ORG_FOLLOWERS_VALUE = "organizationFollowers";
+  
+  public PeopleConnection(LinkedInClient linkedinClient) {
+    super(linkedinClient);
+  }
+  
+  /**
+   * Search followers of an organization by keyword.
+   *
+   * @param organizationURN URN of the organization (urn:li:organization:{id})
+   * @param keywords The search string (partial name, etc.)
+   * @param count Max number of results to return
+   * @return list of follower results with URNs, names, headline, photo, etc.
+   */
+  public List<FollowerResult> searchOrganizationFollowers(URN organizationURN, String keywords,
+      Integer count) {
+    ValidationUtils.verifyParameterPresence("organizationURN", organizationURN);
+    ValidationUtils.verifyParameterPresence("keywords", keywords);
+    
+    List<Parameter> params = new ArrayList<>();
+    params.add(Parameter.with(QUERY_KEY, ORG_FOLLOWERS_VALUE));
+    params.add(Parameter.with(KEYWORDS_KEY, keywords));
+    params.add(Parameter.with(ORG_KEY, organizationURN.toString()));
+    this.addStartAndCountParams(params, null, count);
+    
+    return this.getListFromQuery(PEOPLE_TYPEAHEAD, FollowerResult.class,
+        params.toArray(new Parameter[0]));
+  }
+}

--- a/src/main/java/com/echobox/api/linkedin/types/people/FollowerResult.java
+++ b/src/main/java/com/echobox/api/linkedin/types/people/FollowerResult.java
@@ -28,30 +28,22 @@ import lombok.Setter;
  * @author Myrto Papakonstantinou
  */
 
+@Getter
+@Setter
 public class FollowerResult {
   
-  @Getter
-  @Setter
   @LinkedIn
   private String member;
   
-  @Getter
-  @Setter
   @LinkedIn
   private String firstName;
   
-  @Getter
-  @Setter
   @LinkedIn
   private String lastName;
   
-  @Getter
-  @Setter
   @LinkedIn
   private String headline;
   
-  @Getter
-  @Setter
   @LinkedIn
   private String photo;
 }

--- a/src/main/java/com/echobox/api/linkedin/types/people/FollowerResult.java
+++ b/src/main/java/com/echobox/api/linkedin/types/people/FollowerResult.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.api.linkedin.types.people;
+
+
+import com.echobox.api.linkedin.jsonmapper.LinkedIn;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Represents a follower result returned by the People Typeahead API.
+ *
+ * @author Myrto Papakonstantinou
+ */
+
+public class FollowerResult {
+  
+  @Getter
+  @Setter
+  @LinkedIn
+  private String member;
+  
+  @Getter
+  @Setter
+  @LinkedIn
+  private String firstName;
+  
+  @Getter
+  @Setter
+  @LinkedIn
+  private String lastName;
+  
+  @Getter
+  @Setter
+  @LinkedIn
+  private String headline;
+  
+  @Getter
+  @Setter
+  @LinkedIn
+  private String photo;
+}


### PR DESCRIPTION
### Description of Changes

Add support for the People Typeahead API; specifically to be able to search for followers of an organization using a keyword.

### Documentation

Not Application

### Risks & Impacts

Relatively low risk as this is new functionality and doesn't touch existing endpoints.

### Testing
Build the jar and tested locally

## Final Checklist

Please tick once completed.

- [X] Build passes.
- [X] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [X] Change log has been updated.