### PR TITLE
SL-15201 Update API version to 202510

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,3 +242,6 @@ parameter type of `customizeConnection`
 
 ## 8.1.0 (August 27, 2025)
 * Add support for LinkedIn's People Typeahead API to search for an organization's followers.
+* 
+## 8.1.1 (November 11, 2025)
+* Update the default API version to 202510.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,7 @@ parameter type of `customizeConnection`
 
 ## 8.1.0 (August 27, 2025)
 * Add support for LinkedIn's People Typeahead API to search for an organization's followers.
-* 
+
 ## 8.1.1 (November 11, 2025)
 * Update the default API version to 202510.
+* Adding a new commit to make the CI work

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>8.0.1</version>
+  <version>8.1.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-linkedin-sdk</artifactId>
-  <version>8.1.0</version>
+  <version>8.1.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
+++ b/src/main/java/com/echobox/api/linkedin/client/DefaultLinkedInClient.java
@@ -123,7 +123,7 @@ public class DefaultLinkedInClient extends BaseLinkedInClient
   /**
    * Default LinkedIn-version header
    */
-  public static final String DEFAULT_VERSIONED_MONTH = "202411";
+  public static final String DEFAULT_VERSIONED_MONTH = "202510";
   
   /**
    * Request header of protocol


### PR DESCRIPTION
### Description of Changes

Updates the version number of the project.
Updates the default LinkedIn API version number to the latest.
Updates the project documentation.

### Documentation

N/A

### Risks & Impacts

The only risk is in updating the default LinkedIn API version and that can be overridden by the caller.

### Testing

Unit tests pass - testing against Echobox will follow.

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.